### PR TITLE
Add support for transformers & fix bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Change log
 
-## Adding now
+## Adding now (not released yet)
 
 Models: transformers
 
+Extended support to Python 3.6, 3.7, 3.8
+
+Repo: added Github actions
+
 ## modelstore 0.0.1b
 
-First release!
+First release! Supports (and tested on) Python 3.7 only
 
 Storage: GCP buckets, AWS S3 buckets, file systems.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change log
+
+## Adding now
+
+Models: transformers
+
+## modelstore 0.0.1b
+
+First release!
+
+Storage: GCP buckets, AWS S3 buckets, file systems.
+
+Models: `catboost`, `keras`, `torch`, `sklearn`, `xgboost`
+
+Meta-data: Python runtime, user, dependency versions, git hash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,18 @@ this `Makefile` command:
 ```bash
 ❯ make test
 ```
+
+## Run the examples
+
+We have two types of examples:
+
+* `examples-by-ml-library`, which has 1 machine learning model library and writes to three different model stores (GCP, AWS, file system)
+* `examples-by-storage` which has 2 machine learning libraries (`sklearn` and `xgboost`) and writes to one type of model store
+
+To run a single example; for example, the `xgboost` one:
+
+```bash
+❯ cd examples/examples-by-ml-library/xgboost 
+❯ make pyenv # or make pyenv-local if you have made local changes to the modelstore library
+❯ make run # will run the Python script 3 times, with each model store type
+```

--- a/examples/Makefile-example
+++ b/examples/Makefile-example
@@ -11,7 +11,7 @@ pyenv:
 
 pyenv-local: pyenv-uninstall pyenv
 	pip uninstall -y modelstore
-	pip install -e $REPO_ROOT
+	pip install -e $(REPO_ROOT)
 
 pyenv-test: pyenv-uninstall pyenv
 	pip uninstall -y modelstore
@@ -26,4 +26,4 @@ pyenv-uninstall:
 
 refresh:
 	pip uninstall -y modelstore
-	pip install -e $REPO_ROOT
+	pip install -e $(REPO_ROOT)

--- a/examples/examples-by-ml-library/catboost/main.py
+++ b/examples/examples-by-ml-library/catboost/main.py
@@ -4,7 +4,6 @@ import os
 import catboost as ctb
 import click
 from sklearn.datasets import load_diabetes
-from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.model_selection import train_test_split
 
 from modelstore import ModelStore

--- a/examples/examples-by-ml-library/pytorch/main.py
+++ b/examples/examples-by-ml-library/pytorch/main.py
@@ -4,7 +4,6 @@ import os
 import click
 import torch
 from sklearn.datasets import load_diabetes
-from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.model_selection import train_test_split
 from torch import nn
 

--- a/examples/examples-by-ml-library/run_all.sh
+++ b/examples/examples-by-ml-library/run_all.sh
@@ -1,0 +1,14 @@
+function run {
+	cd $1
+	make pyenv-local
+	make run
+	cd ..
+}
+
+run catboost
+run keras
+run pytorch
+run sklearn
+run transformers
+run xgboost
+

--- a/examples/examples-by-ml-library/transformers/Makefile
+++ b/examples/examples-by-ml-library/transformers/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile-ml-lib

--- a/examples/examples-by-ml-library/transformers/requirements.txt
+++ b/examples/examples-by-ml-library/transformers/requirements.txt
@@ -1,0 +1,5 @@
+google-cloud-storage==1.31.0
+boto3==1.14.56
+click==7.1.2
+torch==1.6.0
+transformers==3.2.0

--- a/modelstore/clouds/file_system.py
+++ b/modelstore/clouds/file_system.py
@@ -36,7 +36,9 @@ class FileSystemStorage(CloudStorage):
                 f'Warning: "{_ROOT}" is in the root path, and is a value'
                 + " that this library usually appends. Is this intended?"
             )
-        self.root_dir = os.path.join(root_path, _ROOT)
+        root_path = os.path.abspath(root_path)
+        self.root_dir = root_path
+        logger.info("Root is: %s", self.root_dir)
 
     @classmethod
     def get_name(cls):

--- a/modelstore/clouds/file_system.py
+++ b/modelstore/clouds/file_system.py
@@ -38,7 +38,7 @@ class FileSystemStorage(CloudStorage):
             )
         root_path = os.path.abspath(root_path)
         self.root_dir = root_path
-        logger.info("Root is: %s", self.root_dir)
+        logger.debug("Root is: %s", self.root_dir)
 
     @classmethod
     def get_name(cls):

--- a/modelstore/model_store.py
+++ b/modelstore/model_store.py
@@ -83,6 +83,7 @@ class ModelStore:
         """
         _validate_domain(domain)
         model_id = str(uuid.uuid4())
+        # Warning! Mac OS translates ":" in paths to "/"
         upload_time = datetime.now().strftime("%Y/%m/%d/%H:%M:%S")
         location = self.storage.upload(domain, upload_time, archive_path)
 

--- a/modelstore/models/managers.py
+++ b/modelstore/models/managers.py
@@ -20,16 +20,17 @@ from modelstore.models.missingmanager import MissingDepManager
 from modelstore.models.modelmanager import ModelManager
 from modelstore.models.pytorch import PyTorchManager
 from modelstore.models.sklearn import SKLearnManager
+from modelstore.models.transformers import TransformersManager
 from modelstore.models.xgboost import XGBoostManager
 
 ML_LIBRARIES = {
     "catboost": CatBoostManager,
-    "pytorch": PyTorchManager,  # Adding twice as this is a common typo
-    "torch": PyTorchManager,
-    "sklearn": SKLearnManager,
-    "xgboost": XGBoostManager,
-    "pytorch": PyTorchManager,
     "keras": KerasManager,
+    "pytorch": PyTorchManager,  # Adding twice as this is a common typo
+    "sklearn": SKLearnManager,
+    "torch": PyTorchManager,
+    "transformers": TransformersManager,
+    "xgboost": XGBoostManager,
 }
 
 

--- a/modelstore/models/transformers.py
+++ b/modelstore/models/transformers.py
@@ -1,0 +1,79 @@
+#    Copyright 2020 Neal Lathia
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import os
+from functools import partial
+
+from modelstore.models.modelmanager import ModelManager
+
+# pylint disable=import-outside-toplevel
+
+
+class TransformersManager(ModelManager):
+
+    """
+    Model persistence for Transformer models:
+    https://huggingface.co/transformers/main_classes/model.html#transformers.TFPreTrainedModel.save_pretrained
+    https://github.com/huggingface/transformers/blob/e50a931c118b9f55f77a743bf703f436bf7a7c29/src/transformers/modeling_utils.py#L676
+
+    """
+
+    @classmethod
+    def required_dependencies(cls) -> list:
+        return ["transformers"]
+
+    @classmethod
+    def optional_dependencies(cls) -> list:
+        """ Returns a list of dependencies that, if installed
+        are useful to log info about """
+        deps = super().optional_dependencies()
+        return deps + ["torch", "tensorflow"]
+
+    def _required_kwargs(self):
+        return ["model", "tokenizer"]
+
+    def _get_functions(self, **kwargs) -> list:
+        return [
+            partial(
+                _save_transformers,
+                config=kwargs["config"],
+                model=kwargs["model"],
+                tokenizer=kwargs["tokenizer"],
+            ),
+        ]
+
+
+def _save_transformers(
+    tmp_dir: str,
+    config: "transformers.PretrainedConfig",
+    model: "transformers.PreTrainedModel",
+    token: "transformers.PreTrainedTokenizerBase",
+) -> str:
+    import transformers
+
+    if config and not isinstance(config, transformers.PretrainedConfig):
+        raise TypeError("Config is not a transformers.PretrainedConfig!")
+    if not isinstance(model, transformers.PreTrainedModel):
+        raise TypeError("Model is not a transformers.PreTrainedModel!")
+    if token and not isinstance(token, transformers.PreTrainedTokenizerBase):
+        raise TypeError(
+            "Tokenizer is not a transformers.PreTrainedTokenizerBase!"
+        )
+
+    model_dir = os.path.join(tmp_dir, "transformers")
+    if config is not None:
+        config.save_pretrained(model_dir)
+    model.save_pretrained(model_dir)
+    token.save_pretrained(model_dir)
+    return model_dir

--- a/modelstore/models/transformers.py
+++ b/modelstore/models/transformers.py
@@ -58,7 +58,7 @@ def _save_transformers(
     tmp_dir: str,
     config: "transformers.PretrainedConfig",
     model: "transformers.PreTrainedModel",
-    token: "transformers.PreTrainedTokenizerBase",
+    tokenizer: "transformers.PreTrainedTokenizerBase",
 ) -> str:
     import transformers
 
@@ -66,14 +66,17 @@ def _save_transformers(
         raise TypeError("Config is not a transformers.PretrainedConfig!")
     if not isinstance(model, transformers.PreTrainedModel):
         raise TypeError("Model is not a transformers.PreTrainedModel!")
-    if token and not isinstance(token, transformers.PreTrainedTokenizerBase):
+    if tokenizer and not isinstance(
+        tokenizer, transformers.PreTrainedTokenizerBase
+    ):
         raise TypeError(
             "Tokenizer is not a transformers.PreTrainedTokenizerBase!"
         )
 
     model_dir = os.path.join(tmp_dir, "transformers")
+    model.save_pretrained(model_dir)
     if config is not None:
         config.save_pretrained(model_dir)
-    model.save_pretrained(model_dir)
-    token.save_pretrained(model_dir)
+    if tokenizer is not None:
+        tokenizer.save_pretrained(model_dir)
     return model_dir

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,5 +15,6 @@ scikit-learn==0.23.2
 tensorflow==2.3.0
 torch==1.6.0
 torchvision==0.7.0
+transformers==3.2.0
 twine==3.2.0
 xgboost==1.2.0

--- a/tests/clouds/test_file_system.py
+++ b/tests/clouds/test_file_system.py
@@ -41,7 +41,7 @@ def test_name(fs_model_store):
 
 def test_validate(fs_model_store):
     assert fs_model_store.validate()
-    assert not os.path.exists(fs_model_store.root_dir)
+    assert os.path.exists(fs_model_store.root_dir)
 
 
 def test_upload(fs_model_store, tmp_path):

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -1,0 +1,91 @@
+#    Copyright 2020 Neal Lathia
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import json
+import os
+
+import pytest
+from transformers import (
+    AutoConfig,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    DistilBertForSequenceClassification,
+    DistilBertTokenizer,
+)
+from transformers.file_utils import CONFIG_NAME
+
+from modelstore.models.transformers import (
+    TransformersManager,
+    _save_transformers,
+)
+
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def model_name():
+    return "distilbert-base-cased"
+
+
+@pytest.fixture
+def model_config(model_name):
+    return AutoConfig.from_pretrained(
+        model_name, num_labels=3, finetuning_task="mnli",
+    )
+
+
+@pytest.fixture
+def tokenizer(model_name):
+    return AutoTokenizer.from_pretrained(model_name)
+
+
+@pytest.fixture()
+def model(model_name, model_config):
+    return AutoModelForSequenceClassification.from_pretrained(
+        model_name, config=model_config,
+    )
+
+
+def test_required_kwargs():
+    mngr = TransformersManager()
+    assert mngr._required_kwargs() == ["model", "tokenizer"]
+
+
+def test_get_functions():
+    mngr = TransformersManager()
+    assert len(mngr._get_functions(config="c", model="m", tokenizer="t")) == 1
+
+
+def test_save_transformers(model_config, model, tokenizer, tmp_path):
+    exp = os.path.join(tmp_path, "transformers")
+    file_path = _save_transformers(tmp_path, model_config, model, tokenizer)
+    assert exp == file_path
+
+    # Validate config
+    config_file = os.path.join(exp, CONFIG_NAME)
+    assert os.path.exists(config_file)
+    with open(config_file, "r") as lines:
+        config_json = json.loads(lines.read())
+    assert config_json == json.loads(model_config.to_json_string())
+
+    # Validate model
+    model = AutoModelForSequenceClassification.from_pretrained(
+        file_path, config=model_config,
+    )
+    assert isinstance(model, DistilBertForSequenceClassification)
+
+    # Validate tokenizer
+    token = AutoTokenizer.from_pretrained(file_path)
+    assert isinstance(token, DistilBertTokenizer)


### PR DESCRIPTION
- Adds `transformers` as a model type, tests, and examples
- Fixes bugs in the `Makefile`s, and in the test (repo name)
- Cleans up the examples - removing unused imports, adds utility scripts
- Fixes a bug where the file system model store would have a double prefix in its path