### PR TITLE
Add support for Annoy models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@
 
 🆕  Read a specific model's metadata with `modelstore.get_model_info()`
 
+🆕  Added [Annoy](https://github.com/spotify/annoy) support.
+
 ## modelstore 0.0.65
 
 🆕  Added model states, and updated listing models to listing by state.
 
 🆕  Created a unified upload function. You can now use `modelstore.upload()` for all ML frameworks.
 
-🆕  Added Gensim support.
+🆕  Added [Gensim](https://github.com/RaRe-Technologies/gensim) support.
 
 🆕  Added Azure blob storage support.
 

--- a/examples/examples-by-ml-library/main.py
+++ b/examples/examples-by-ml-library/main.py
@@ -3,6 +3,7 @@ import json
 import click
 
 from models import (
+    run_annoy_example,
     run_catboost_example,
     run_fastai_example,
     run_gensim_example,
@@ -19,6 +20,7 @@ from models import (
 from modelstores import create_model_store
 
 EXAMPLES = {
+    "annoy": run_annoy_example,
     "catboost": run_catboost_example,
     "fastai": run_fastai_example,
     "gensim": run_gensim_example,

--- a/examples/examples-by-ml-library/requirements.txt
+++ b/examples/examples-by-ml-library/requirements.txt
@@ -8,6 +8,7 @@ azure-core==1.13.0
 azure-storage-blob==12.8.0
 
 # Machine learning libraries
+annoy==1.17.0
 catboost==0.24.1
 fastai==2.4.1
 gensim==4.0.1

--- a/examples/examples-by-ml-library/run-all.sh
+++ b/examples/examples-by-ml-library/run-all.sh
@@ -1,6 +1,6 @@
 set -e
 backends=( filesystem aws azure gcloud hosted )
-frameworks=( catboost fastai gensim keras lightgbm file pytorch pytorch-lightning sklearn tensorflow transformers xgboost )
+frameworks=( annoy catboost fastai gensim keras lightgbm file pytorch pytorch-lightning sklearn tensorflow transformers xgboost )
 
 for framework in "${frameworks[@]}"
 do

--- a/modelstore/meta/dependencies.py
+++ b/modelstore/meta/dependencies.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 
+import pkg_resources
 from modelstore.models.common import save_json
 from modelstore.utils.log import logger
 
@@ -16,6 +17,9 @@ def _get_version(modname: str) -> str:
         else:
             mod = importlib.import_module(modname)
         return mod.__version__
+    except AttributeError:
+        #  Annoy does not have a __version__
+        return pkg_resources.get_distribution(modname).version
     except ImportError:
         logger.debug("%s is not installed.", modname)
         return None

--- a/modelstore/models/annoy.py
+++ b/modelstore/models/annoy.py
@@ -37,7 +37,7 @@ class AnnoyManager(ModelManager):
         return ["annoy"]
 
     def _required_kwargs(self):
-        return ["model"]
+        return ["model", "metric", "num_trees"]
 
     def matches_with(self, **kwargs) -> bool:
         # pylint: disable=import-outside-toplevel
@@ -60,15 +60,19 @@ class AnnoyManager(ModelManager):
         ]
 
     def _get_params(self, **kwargs) -> dict:
-        return {}
+        return {
+            "num_dimensions": kwargs["model"].f,
+            "num_trees": kwargs["num_trees"],
+            "metric": kwargs["metric"],
+        }
 
     def load(self, model_path: str, meta_data: dict) -> Any:
         # pylint: disable=import-outside-toplevel
         from annoy import AnnoyIndex
 
         # Extract these from the meta_data
-        num_dimensions = 10
-        metric = "angular"
+        num_dimensions = int(meta_data["model"]["parameters"]["num_dimensions"])
+        metric = meta_data["model"]["parameters"]["metric"]
 
         model = AnnoyIndex(num_dimensions, metric)
         model.load(_model_file_path(model_path))

--- a/modelstore/models/annoy.py
+++ b/modelstore/models/annoy.py
@@ -49,9 +49,6 @@ class AnnoyManager(ModelManager):
         if not self.matches_with(**kwargs):
             raise TypeError("Model is not an AnnoyIndex!")
 
-        # pool parameter, from the catboost docs:
-        # The dataset previously used for training.
-        # This parameter is required if the model contains categorical features and the output format is cpp, python, or JSON.
         return [
             partial(
                 save_model,

--- a/modelstore/models/annoy.py
+++ b/modelstore/models/annoy.py
@@ -1,0 +1,86 @@
+#    Copyright 2020 Neal Lathia
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+import os
+from functools import partial
+from typing import Any
+
+from modelstore.models.model_manager import ModelManager
+from modelstore.storage.storage import CloudStorage
+from modelstore.utils.log import logger
+
+MODEL_FILE = "model.ann"
+
+
+class AnnoyManager(ModelManager):
+
+    """
+    Model persistence for Annoy models:
+    https://github.com/spotify/annoy
+    """
+
+    def __init__(self, storage: CloudStorage = None):
+        super().__init__("annoy", storage)
+
+    @classmethod
+    def required_dependencies(cls) -> list:
+        return ["annoy"]
+
+    def _required_kwargs(self):
+        return ["model"]
+
+    def matches_with(self, **kwargs) -> bool:
+        # pylint: disable=import-outside-toplevel
+        from annoy import AnnoyIndex
+
+        return isinstance(kwargs.get("model"), AnnoyIndex)
+
+    def _get_functions(self, **kwargs) -> list:
+        if not self.matches_with(**kwargs):
+            raise TypeError("Model is not an AnnoyIndex!")
+
+        # pool parameter, from the catboost docs:
+        # The dataset previously used for training.
+        # This parameter is required if the model contains categorical features and the output format is cpp, python, or JSON.
+        return [
+            partial(
+                save_model,
+                model=kwargs["model"],
+            ),
+        ]
+
+    def _get_params(self, **kwargs) -> dict:
+        return {}
+
+    def load(self, model_path: str, meta_data: dict) -> Any:
+        # pylint: disable=import-outside-toplevel
+        from annoy import AnnoyIndex
+
+        # Extract these from the meta_data
+        num_dimensions = 10
+        metric = "angular"
+
+        model = AnnoyIndex(num_dimensions, metric)
+        model.load(_model_file_path(model_path))
+        return model
+
+
+def _model_file_path(tmp_dir: str) -> str:
+    return os.path.join(tmp_dir, MODEL_FILE)
+
+
+def save_model(tmp_dir: str, model: "annoy.AnnoyIndex") -> str:
+    file_path = _model_file_path(tmp_dir)
+    logger.debug("Saving annoy model to %s", file_path)
+    model.save(file_path)
+    return file_path

--- a/modelstore/models/managers.py
+++ b/modelstore/models/managers.py
@@ -14,6 +14,7 @@
 from typing import Iterator
 
 from modelstore.meta.dependencies import module_exists
+from modelstore.models.annoy import AnnoyManager
 from modelstore.models.catboost import CatBoostManager
 from modelstore.models.fastai import FastAIManager
 from modelstore.models.gensim import GensimManager
@@ -32,6 +33,7 @@ from modelstore.storage.storage import CloudStorage
 from modelstore.utils.log import logger
 
 ML_LIBRARIES = {
+    "annoy": AnnoyManager,
     "catboost": CatBoostManager,
     "fastai": FastAIManager,
     "file": ModelFileManager,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+annoy==1.17.0
 azure-core==1.13.0
 azure-storage-blob==12.8.0
 black==20.8b1

--- a/tests/meta/test_dependencies.py
+++ b/tests/meta/test_dependencies.py
@@ -32,6 +32,7 @@ def test_get_version():
 
 def test_get_dependency_versions():
     test_deps = [
+        "annoy",
         "pytest",
         "pylint",
         "black",
@@ -40,6 +41,7 @@ def test_get_dependency_versions():
         "a-missing-dependency",
     ]
     expected = {
+        "annoy": "1.17.0",
         "black": "20.8b1",
         "pytest": pytest.__version__,
         "pylint": "2.6.0",

--- a/tests/models/test_annoy.py
+++ b/tests/models/test_annoy.py
@@ -1,0 +1,124 @@
+#    Copyright 2020 Neal Lathia
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+import os
+import random
+
+import pytest
+from annoy import AnnoyIndex
+from modelstore.models.annoy import MODEL_FILE, AnnoyManager, save_model
+
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def annoy_model():
+    num_dimensions = 40
+    model = AnnoyIndex(num_dimensions, "angular")
+    for i in range(1000):
+        vector = [random.gauss(0, 1) for z in range(num_dimensions)]
+        model.add_item(i, vector)
+    model.build(10)
+    return model
+
+
+@pytest.fixture
+def annoy_manager():
+    return AnnoyManager()
+
+
+def assert_same_model(model_a: AnnoyIndex, model_b: AnnoyIndex):
+    assert type(model_a) == type(model_b)
+    assert model_a.get_nns_by_item(0, 10) == model_b.get_nns_by_item(0, 10)
+
+
+def test_model_info(annoy_manager, annoy_model):
+    exp = {"library": "annoy", "type": "Annoy"}
+    res = annoy_manager._model_info(model=annoy_model)
+    assert exp == res
+
+
+@pytest.mark.parametrize(
+    "ml_library,should_match",
+    [
+        ("annoy", True),
+        ("sklearn", False),
+    ],
+)
+def test_is_same_library(annoy_manager, ml_library, should_match):
+    assert (
+        annoy_manager._is_same_library({"library": ml_library}) == should_match
+    )
+
+
+def test_model_data(annoy_manager, annoy_model):
+    exp = {}
+    res = annoy_manager._model_data(model=annoy_model)
+    assert exp == res
+
+
+def test_required_kwargs(annoy_manager):
+    assert annoy_manager._required_kwargs() == ["model", "metric", "num_trees"]
+
+
+def test_matches_with(annoy_manager, annoy_model):
+    assert annoy_manager.matches_with(model=annoy_model)
+    assert not annoy_manager.matches_with(model="a-string-value")
+    assert not annoy_manager.matches_with(catboost_model=annoy_model)
+
+
+def test_get_functions(annoy_manager, annoy_model):
+    assert len(annoy_manager._get_functions(model=annoy_model)) == 1
+
+
+def test_get_params(annoy_manager, annoy_model):
+    exp = {
+        "num_dimensions": annoy_model.f,
+        "num_trees": 10,
+        "metric": "angular",
+    }
+    res = annoy_manager._get_params(
+        model=annoy_model, num_trees=10, metric="angular"
+    )
+    assert exp == res
+
+
+def test_save_model(tmp_path, annoy_model):
+    exp = os.path.join(tmp_path, MODEL_FILE)
+    res = save_model(tmp_path, model=annoy_model)
+    assert os.path.exists(exp)
+    assert res == exp
+
+    loaded_model = AnnoyIndex(annoy_model.f, "angular")
+    loaded_model.load(res)
+    assert_same_model(annoy_model, loaded_model)
+
+
+def test_load_model(tmp_path, annoy_manager, annoy_model):
+    # Save the model to a tmp directory
+    model_path = os.path.join(tmp_path, MODEL_FILE)
+    annoy_model.save(model_path)
+
+    #  Load the model
+    loaded_model = annoy_manager.load(
+        tmp_path,
+        {
+            "model": {
+                "parameters": {"num_dimensions": 40, "metric": "angular"},
+            }
+        },
+    )
+
+    # Expect the two to be the same
+    assert_same_model(annoy_model, loaded_model)

--- a/tests/models/test_managers.py
+++ b/tests/models/test_managers.py
@@ -21,7 +21,7 @@ from modelstore.models.xgboost import XGBoostManager
 
 def test_iter_libraries():
     mgrs = {library: manager for library, manager in managers.iter_libraries()}
-    assert len(mgrs) == 12
+    assert len(mgrs) == 13
     assert isinstance(mgrs["sklearn"], SKLearnManager)
     assert isinstance(mgrs["pytorch"], PyTorchManager)
     assert isinstance(mgrs["xgboost"], XGBoostManager)


### PR DESCRIPTION
Annoy doesn't have a `__version__` so `_get_version()` has been extended to also use `pkg_resources` https://github.com/spotify/annoy/issues/572