### PR TITLE
Upload extra files alongside a model archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Unreleased
+
+🆕  Need to upload additional files alongside your model? You can now use the `extras=` kwarg in `modelstore.upload()` to point modelstore to a file (or list of files) to upload as well.
+
 ## modelstore 0.0.71
 
 🆕  Load models straight into memory! Model Store previously had `modelstore.download()` to download an artifact archive to a local path, it now also has `modelstore.load()` to load a model straight into memory.

--- a/examples/examples-by-storage/Makefile
+++ b/examples/examples-by-storage/Makefile
@@ -6,4 +6,3 @@ run:
 	@python main.py --modelstore-in azure
 	@python main.py --modelstore-in gcloud
 	@python main.py --modelstore-in filesystem
-	@python main.py --modelstore-in hosted

--- a/examples/examples-by-storage/main.py
+++ b/examples/examples-by-storage/main.py
@@ -94,11 +94,6 @@ def main(modelstore_in):
         model = modelstore.load(model_domain, model_id)
         print(f"\t  Loaded a {type(model)} model")
 
-    if modelstore_in == "hosted":
-        # The rest is currently not implemented in the 'hosted'
-        # modelstore
-        return
-
     # Create a new model state
     state_prod = "production"
     print(f"✅  Creating model state={state_prod}:")

--- a/examples/examples-by-storage/main.py
+++ b/examples/examples-by-storage/main.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+import time
 
 import click
 
@@ -16,18 +17,19 @@ from modelstores import create_model_store
     ),
 )
 def main(modelstore_in):
-    print(f"\n🆕  Running modelstore example with {modelstore_in} backend.")
+    print(f"🆕  Running modelstore example with {modelstore_in} backend.")
 
     # Create a model store instance
     modelstore = create_model_store(modelstore_in)
+    model_domain = "diabetes-boosting-demo"
 
     # This demo downloads models; we'll store them into a temporary
     # directory
     tmp_dir = tempfile.mkdtemp()
 
-    # In this demo, we train two models, so that we can demonstrate
-    # how modelstore keeps track of uploaded models for us
-    model_ids = []
+    # # In this demo, we train two models, so that we can demonstrate
+    # # how modelstore keeps track of uploaded models for us
+    model_ids = {}
     for model_type in ["sklearn", "xgboost"]:
         print(f"🤖  Training a {model_type} model...")
         model, result = train(model_type)
@@ -37,16 +39,23 @@ def main(modelstore_in):
         with open(results_file, "w") as out:
             out.write(json.dumps(result))
 
-        model_domain = "diabetes-boosting-demo"
         print(f"⤴️  Uploading to the {model_domain} domain.")
         meta_data = modelstore.upload(
             model_domain, model=model, extras=results_file
         )
 
+        # Currently, modelstore stores artifacts in a prefix
+        #  that has the training timestamp encoded in it. If
+        # we upload two models at the exact same second, the
+        # second one will overwrite the first. So we add in an
+        # artifical sleep to split things out
+        time.sleep(1)
+
         # The upload returns meta-data about the model that was uploaded
         # This meta-data has also been sync'ed into the s3 bucket
-        print(f"✅  Finished uploading the {model_type} model!")
-        model_ids.append(meta_data["model"]["model_id"])
+        model_id = meta_data["model"]["model_id"]
+        print(f"✅  Finished uploading the {model_type} model: {model_id}")
+        model_ids[model_type] = model_id
 
     # We now have push an additional two models into our store
     # How does modelstore enable you to manage them?
@@ -63,10 +72,10 @@ def main(modelstore_in):
     for version in versions:
         print(f"\t  Domain: {model_domain} has model with id={version}")
 
-    # Download models
+    # Download models back
     print(f"⤵️  Downloading {model_domain} models:")
-    for model_id in model_ids:
-        print(f"⤵️  Downloading {model_id}:")
+    for model_type, model_id in model_ids.items():
+        print(f"\t  Downloading {model_type}={model_id}")
         target = os.path.join(tmp_dir, f"downloaded-{model_type}-model")
         os.makedirs(target, exist_ok=True)
 
@@ -75,12 +84,15 @@ def main(modelstore_in):
             domain=model_domain,
             model_id=model_id,
         )
-        print(f"⤵️  Downloaded to: {model_path}")
+        print(f"\t  Downloaded to: {model_path}")
 
-    # Load models straight into memory
-    for model_id in model_ids:
+    # You don't need to download models manually, you can
+    # also load models straight into memory
+    print(f"💡  Loading models into memory")
+    for model_type, model_id in model_ids.items():
+        print(f"\t  Loading {model_type}={model_id}")
         model = modelstore.load(model_domain, model_id)
-        print(f"⤵️  Loaded a {type(model)} model")
+        print(f"\t  Loaded a {type(model)} model")
 
     if modelstore_in == "hosted":
         # The rest is currently not implemented in the 'hosted'
@@ -93,8 +105,9 @@ def main(modelstore_in):
     modelstore.create_model_state(state_prod)
 
     # Set the first model to the production state
-    print(f"✅  Setting model_id={versions[0]} to state={state_prod}:")
-    modelstore.set_model_state(model_domain, versions[0], state_prod)
+    prod_model = list(model_ids.values())[0]
+    print(f"✅  Setting model_id={prod_model} to state={state_prod}:")
+    modelstore.set_model_state(model_domain, prod_model, state_prod)
 
     # List the models that are in production
     print(

--- a/examples/examples-by-storage/model.py
+++ b/examples/examples-by-storage/model.py
@@ -1,0 +1,40 @@
+import numpy as np
+import xgboost as xgb
+from sklearn.datasets import load_diabetes
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
+
+
+def train(model_type):
+    diabetes = load_diabetes()
+    X_train, X_test, y_train, y_test = train_test_split(
+        diabetes.data, diabetes.target, test_size=0.1, random_state=13
+    )
+
+    if model_type == "sklearn":
+        params = {
+            "n_estimators": 500,
+            "max_depth": 4,
+            "min_samples_split": 5,
+            "learning_rate": 0.01,
+            "loss": "ls",
+        }
+        model = GradientBoostingRegressor(**params)
+    elif model_type == "xgboost":
+        model = xgb.XGBRegressor(
+            objective="reg:squarederror",
+            colsample_bytree=0.3,
+            learning_rate=0.1,
+            max_depth=5,
+            alpha=10,
+            n_estimators=10,
+        )
+    else:
+        raise ValueError(f"Unknown model type: {model_type}")
+
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    rmse = np.sqrt(mean_squared_error(y_test, preds))
+    print(f"📈  Trained a model with RMSE={rmse}.")
+    return model, {"result": rmse}

--- a/modelstore/model_store.py
+++ b/modelstore/model_store.py
@@ -24,6 +24,7 @@ from modelstore.storage.gcloud import GCLOUD_EXISTS, GoogleCloudStorage
 from modelstore.storage.hosted import HostedStorage
 from modelstore.storage.local import FileSystemStorage
 from modelstore.storage.storage import CloudStorage
+from modelstore.utils.log import logger
 
 
 @dataclass(frozen=True)
@@ -122,6 +123,7 @@ class ModelStore:
         # pylint: disable=no-member
         for manager in self._managers:
             if manager.matches_with(**kwargs):
+                logger.debug(f"Auto matched with: %s", manager.ml_library)
                 return manager.upload(domain, **kwargs)
         raise ValueError(
             "unable to upload: could not find matching manager (did you add all of the required kwargs?)"

--- a/modelstore/models/model_manager.py
+++ b/modelstore/models/model_manager.py
@@ -139,10 +139,6 @@ class ModelManager(ABC):
         """
         Creates the `artifacts.tar.gz` archive which contains
         all of the files of the model
-
-        Uploads the archive to storage. This function returns
-        a dictionary of meta-data that is associated with this model,
-        including an id.
         """
         self._validate_kwargs(**kwargs)
         archive_name = "artifacts.tar.gz"
@@ -164,11 +160,10 @@ class ModelManager(ABC):
     def upload(self, domain: str, **kwargs) -> dict:
         """
         Creates the `artifacts.tar.gz` archive which contains
-        all of the files of the model
+        all of the files of the model and uploads the archive to storage.
 
-        Uploads the archive to storage. This function returns
-        a dictionary of meta-data that is associated with this model,
-        including an id.
+        This function returns a dictionary of meta-data that is associated
+        with this model, including an id.
         """
         _validate_domain(domain)
         self._validate_kwargs(**kwargs)
@@ -186,11 +181,14 @@ class ModelManager(ABC):
         # Meta-data about the code
         code_meta = metadata.generate_for_code(self._get_dependencies())
 
-        # Meta-data about the model location
+        # Create the model archive and return
+        # meta-data about its location
         archive_path = self._create_archive(**kwargs)
 
         # Upload the model archive and any additional extras
-        storage_meta = self.storage.upload(domain, model_id, archive_path)
+        storage_meta = self.storage.upload(
+            domain, model_id, archive_path, extras=kwargs.get("extras")
+        )
 
         # Generate the combined meta-data and add it to the store
         meta_data = metadata.generate(model_meta, storage_meta, code_meta)

--- a/modelstore/models/model_manager.py
+++ b/modelstore/models/model_manager.py
@@ -187,7 +187,7 @@ class ModelManager(ABC):
 
         # Upload the model archive and any additional extras
         storage_meta = self.storage.upload(
-            domain, model_id, archive_path, extras=kwargs.get("extras")
+            domain, archive_path, extras=kwargs.get("extras")
         )
 
         # Generate the combined meta-data and add it to the store

--- a/modelstore/models/model_manager.py
+++ b/modelstore/models/model_manager.py
@@ -188,12 +188,15 @@ class ModelManager(ABC):
 
         # Meta-data about the model location
         archive_path = self._create_archive(**kwargs)
+
+        # Upload the model archive and any additional extras
         storage_meta = self.storage.upload(domain, model_id, archive_path)
 
         # Generate the combined meta-data and add it to the store
         meta_data = metadata.generate(model_meta, storage_meta, code_meta)
         self.storage.set_meta_data(domain, model_id, meta_data)
         os.remove(archive_path)
+
         return meta_data
 
 

--- a/modelstore/models/sklearn.py
+++ b/modelstore/models/sklearn.py
@@ -101,9 +101,6 @@ class SKLearnManager(ModelManager):
         return convert_numpy(params)
 
     def load(self, model_path: str, meta_data: dict) -> Any:
-        """
-        Loads a joblib model, stored in model_path, back into memory
-        """
         # @Future: check if loading into same version of joblib
         # as was used for saving
         file_name = os.path.join(model_path, MODEL_JOBLIB)

--- a/modelstore/storage/blob_storage.py
+++ b/modelstore/storage/blob_storage.py
@@ -85,31 +85,36 @@ class BlobStorage(CloudStorage):
         versions_path = get_versions_path(domain, state_name)
         return os.path.join(versions_path, f"{model_id}.json")
 
+    def _upload_extra(self, local_path: str, remote_path: str):
+        if os.path.isdir(local_path):
+            #  Currently ignoring directories
+            return
+        local_file_name = os.path.split(local_path)[1]
+        if local_file_name == "artifacts.tar.gz":
+            raise ValueError(
+                "Name conflict in extras: cannot use 'artifacts.tar.gz'"
+            )
+        remote_file_path = os.path.join(remote_path, local_file_name)
+        self._push(local_path, remote_file_path)
+
     def upload(
         self,
         domain: str,
-        model_id: str,
         local_path: str,
         extras: Optional[Union[str, list]] = None,
     ) -> dict:
-        # @TODO model_id is unused
+        # Upload the archive into storage
         archive_remote_path = get_archive_path(domain, local_path)
         prefix = self._push(local_path, archive_remote_path)
         if extras:
+            # If any extras have been defined, they are uploaded
+            # to the same place
             remote_path = os.path.split(archive_remote_path)[0]
             if isinstance(extras, list):
                 for extra_path in extras:
-                    # @TODO ignore directories
-                    remote_file_path = os.path.join(
-                        remote_path, os.path.split(extra_path)[1]
-                    )
-                    self._push(extra_path, remote_file_path)
+                    self._upload_extra(extra_path, remote_path)
             else:
-                # @TODO ignore directories
-                remote_file_path = os.path.join(
-                    remote_path, os.path.split(extras)[1]
-                )
-                self._push(extras, remote_file_path)
+                self._upload_extra(extras, remote_path)
 
         return self._storage_location(prefix)
 

--- a/modelstore/storage/storage.py
+++ b/modelstore/storage/storage.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 from abc import ABC, ABCMeta, abstractmethod
-from typing import Optional
+from typing import Optional, Union
 
 from modelstore.meta.dependencies import module_exists
 
@@ -38,8 +38,17 @@ class CloudStorage(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def upload(self, domain: str, model_id: str, local_path: str) -> dict:
-        """ Uploads an archive to this type of storage"""
+    def upload(
+        self,
+        domain: str,
+        model_id: str,
+        local_path: str,
+        extras: Optional[Union[str, list]] = None,
+    ) -> dict:
+        """Uploads an archive to this type of storage
+        :param extras can be a path to a file or list of files
+        if these are specified, those files are upload
+        to the same storage prefix too."""
         raise NotImplementedError()
 
     @abstractmethod

--- a/modelstore/storage/storage.py
+++ b/modelstore/storage/storage.py
@@ -41,7 +41,6 @@ class CloudStorage(ABC):
     def upload(
         self,
         domain: str,
-        model_id: str,
         local_path: str,
         extras: Optional[Union[str, list]] = None,
     ) -> dict:

--- a/tests/models/test_model_manager.py
+++ b/tests/models/test_model_manager.py
@@ -14,7 +14,7 @@
 import os
 import tarfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional, Union
 
 import pytest
 from modelstore.models.model_manager import ModelManager
@@ -30,7 +30,12 @@ class MockCloudStorage(FileSystemStorage):
         super().__init__(root_path=str(tmpdir))
         self.called = False
 
-    def upload(self, domain: str, model_id: str, local_path: str):
+    def upload(
+        self,
+        domain: str,
+        local_path: str,
+        extras: Optional[Union[str, list]] = None,
+    ):
         self.called = True
 
 

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -120,7 +120,7 @@ def test_upload(mock_blob_storage, tmp_path):
         mock_blob_storage.root_dir,
         get_archive_path("test-domain", source),
     )
-    rsp = mock_blob_storage.upload("test-domain", "test-model-id", source)
+    rsp = mock_blob_storage.upload("test-domain", source)
     assert rsp["type"] == "file_system"
     assert rsp["path"] == model_path
     assert os.path.exists(model_path)

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -126,6 +126,35 @@ def test_upload(mock_blob_storage, tmp_path):
     assert os.path.exists(model_path)
 
 
+def test_upload_extras(mock_blob_storage, tmp_path):
+    # A 'model' file to be uploaded
+    source = os.path.join(tmp_path, "test-file.txt")
+    Path(source).touch()
+
+    # An additional file to upload alongside the model
+    extra_path = os.path.join(tmp_path, "extra-file.txt")
+    Path(extra_path).touch()
+
+    # Upload the model
+    rsp = mock_blob_storage.upload("test-domain", source, extras=extra_path)
+    assert rsp["type"] == "file_system"
+
+    # The model will be uploaded to the right place
+    model_path = os.path.join(
+        mock_blob_storage.root_dir,
+        get_archive_path("test-domain", source),
+    )
+    assert rsp["path"] == model_path
+    assert os.path.exists(model_path)
+
+    # The extras are also uploaded alongside the model
+    uploaded_extra_path = os.path.join(
+        os.path.split(model_path)[0],
+        "extra-file.txt",
+    )
+    assert os.path.exists(uploaded_extra_path)
+
+
 def test_download_latest(mock_blob_storage):
     pass
 


### PR DESCRIPTION
There was a feature request to be able to upload other files alongside a model archive. Things like plots (png/jpeg), results (json/csv), or other aspects. This PR adds an optional `extras=` to the `upload()` function to enable a model store user to be able to point to a file/a list of files that they want uploaded. 

For now, they aren't added to the model archive but they are uploaded to the same prefix. The assumption being that these files are primarily for analysis and therefore don't need to be pulled back with `download()`.