### PR TITLE
Add cli to modelstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+🆕   Added CLI functionality! You can now `python -m modelstore download <domain> <model-id> <directory>` to download a model. This requires you to set environment variables.
+
 📈  Added [Prophet](https://facebook.github.io/prophet/) support
 
 🆕 Need to upload additional files alongside your model? You can now use the extras= kwarg in modelstore.upload() to point modelstore to a file (or list of files) to upload as well.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For more details, please refer to [the documentation](https://modelstore.readthe
 ## Features
 
 No tracking server required
-* Pip install and go
+* Pip install and get going!
 * Support for multiple clouds (AWS, GCP, Azure)
 
 Upload: version all your models
@@ -21,6 +21,9 @@ Manage models by domains and states
 Download and load
 * Download model archives by id
 * Load models straight from your storage back into memory
+
+Use as a command line tool
+* Download models from the command line
 
 ## Installation
 
@@ -98,6 +101,8 @@ model_path = model_store.download(
 ```
 
 ## Recorded demo from Data Talks Club
+
+_Note_ the talk below is based on an older version of `modelstore` and the API has been simplified since then.
 
 This interview and demo, recorded with Alexey from the [Data Talks Club](https://datatalks.club/) in July 2021, is based on `modelstore==0.0.6`. Click [here to watch on YouTube](https://www.youtube.com/watch?v=85BWnKmOZl8 "DTC's minis: Model Store").
 

--- a/examples/examples-by-ml-library/modelstores.py
+++ b/examples/examples-by-ml-library/modelstores.py
@@ -18,7 +18,7 @@ def create_aws_model_store() -> ModelStore:
     # A model store in an AWS S3 bucket
     # The modelstore library assumes you have already created
     # an s3 bucket and will raise an exception if it doesn't exist
-    return ModelStore.from_aws_s3(os.environ["AWS_BUCKET_NAME"])
+    return ModelStore.from_aws_s3(os.environ["MODEL_STORE_AWS_BUCKET"])
 
 
 def create_azure_model_store() -> ModelStore:
@@ -27,7 +27,7 @@ def create_azure_model_store() -> ModelStore:
     # 1. You have already created an Azure container
     # 2. You have an os environment variable called AZURE_STORAGE_CONNECTION_STRING
     return ModelStore.from_azure(
-        container_name=os.environ["AZURE_CONTAINER_NAME"],
+        container_name=os.environ["MODEL_STORE_AZURE_CONTAINER"],
     )
 
 
@@ -36,8 +36,8 @@ def create_gcloud_model_store() -> ModelStore:
     # The modelstore library assumes you have already created
     # a Cloud Storage bucket and will raise an exception if it doesn't exist
     return ModelStore.from_gcloud(
-        os.environ["GCP_PROJECT_ID"],
-        os.environ["GCP_BUCKET_NAME"],
+        os.environ["MODEL_STORE_GCP_PROJECT"],
+        os.environ["MODEL_STORE_GCP_BUCKET"],
     )
 
 

--- a/examples/examples-by-storage/modelstores.py
+++ b/examples/examples-by-storage/modelstores.py
@@ -18,7 +18,7 @@ def create_aws_model_store() -> ModelStore:
     # A model store in an AWS S3 bucket
     # The modelstore library assumes you have already created
     # an s3 bucket and will raise an exception if it doesn't exist
-    return ModelStore.from_aws_s3(os.environ["AWS_BUCKET_NAME"])
+    return ModelStore.from_aws_s3(os.environ["MODEL_STORE_AWS_BUCKET"])
 
 
 def create_azure_model_store() -> ModelStore:
@@ -27,7 +27,7 @@ def create_azure_model_store() -> ModelStore:
     # 1. You have already created an Azure container
     # 2. You have an os environment variable called AZURE_STORAGE_CONNECTION_STRING
     return ModelStore.from_azure(
-        container_name=os.environ["AZURE_CONTAINER_NAME"],
+        container_name=os.environ["MODEL_STORE_AZURE_CONTAINER"],
     )
 
 
@@ -36,8 +36,8 @@ def create_gcloud_model_store() -> ModelStore:
     # The modelstore library assumes you have already created
     # a Cloud Storage bucket and will raise an exception if it doesn't exist
     return ModelStore.from_gcloud(
-        os.environ["GCP_PROJECT_ID"],
-        os.environ["GCP_BUCKET_NAME"],
+        os.environ["MODEL_STORE_GCP_PROJECT"],
+        os.environ["MODEL_STORE_GCP_BUCKET"],
     )
 
 

--- a/modelstore/__main__.py
+++ b/modelstore/__main__.py
@@ -1,0 +1,47 @@
+#    Copyright 2021 Neal Lathia
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+import click
+
+from modelstore.storage.util.environment import model_store_from_env
+from modelstore.utils import cli as modelstorecli
+
+
+@click.group()
+def download_model():
+    pass
+
+
+@download_model.command()
+@click.argument("domain", type=str, required=True)
+@click.argument("model_id", type=str, required=True)
+@click.argument("target_dir", type=str, required=False, default=None)
+def download(domain, model_id, target_dir):
+    """Download a model from the modelstore. Usage:\n
+    ❯ python -m modelstore <domain> <model-id> <target-directory>
+    """
+    try:
+        model_store = model_store_from_env()
+        model_store.download(target_dir, domain, model_id)
+        modelstorecli.success(
+            f"✅  Downloaded: {domain}={model_id} to {target_dir}"
+        )
+    except:
+        modelstorecli.failure("❌  Failed to download model:")
+        raise
+
+
+cli = click.CommandCollection(sources=[download_model])
+
+if __name__ == "__main__":
+    cli()

--- a/modelstore/__main__.py
+++ b/modelstore/__main__.py
@@ -11,9 +11,10 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+import os
+
 import click
 
-from modelstore.storage.util.environment import model_store_from_env
 from modelstore.utils import cli as modelstorecli
 
 
@@ -25,16 +26,23 @@ def download_model():
 @download_model.command()
 @click.argument("domain", type=str, required=True)
 @click.argument("model_id", type=str, required=True)
-@click.argument("target_dir", type=str, required=False, default=None)
-def download(domain, model_id, target_dir):
+@click.argument("parent_dir", type=str, required=False, default=None)
+def download(domain: str, model_id: str, parent_dir: str):
     """Download a model from the modelstore. Usage:\n
-    ❯ python -m modelstore <domain> <model-id> <target-directory>
+    ❯ python -m modelstore <domain> <model-id> <parent-directory>
     """
     try:
-        model_store = model_store_from_env()
-        model_store.download(target_dir, domain, model_id)
+        target_dir = (
+            os.path.join(parent_dir, domain, model_id)
+            if parent_dir is not None
+            else os.path.join(domain, model_id)
+        )
+        os.makedirs(target_dir, exist_ok=True)
+
+        model_store = modelstorecli.model_store_from_env()
+        archive_path = model_store.download(target_dir, domain, model_id)
         modelstorecli.success(
-            f"✅  Downloaded: {domain}={model_id} to {target_dir}"
+            f"✅  Downloaded: {domain}={model_id} to {archive_path}"
         )
     except:
         modelstorecli.failure("❌  Failed to download model:")

--- a/modelstore/__main__.py
+++ b/modelstore/__main__.py
@@ -44,6 +44,9 @@ def download(domain: str, model_id: str, parent_dir: str):
         modelstorecli.success(
             f"✅  Downloaded: {domain}={model_id} to {archive_path}"
         )
+    except SystemExit:
+        # Failed to instantiate a model store from environment variables
+        pass
     except:
         modelstorecli.failure("❌  Failed to download model:")
         raise

--- a/modelstore/model_store.py
+++ b/modelstore/model_store.py
@@ -41,7 +41,9 @@ class ModelStore:
     storage: CloudStorage
 
     @classmethod
-    def from_aws_s3(cls, bucket_name: str, region: str = None) -> "ModelStore":
+    def from_aws_s3(
+        cls, bucket_name: Optional[str] = None, region: Optional[str] = None
+    ) -> "ModelStore":
         """Creates a ModelStore instance that stores models to an AWS s3
         bucket.
 
@@ -53,7 +55,7 @@ class ModelStore:
         )
 
     @classmethod
-    def from_azure(cls, container_name: str) -> "ModelStore":
+    def from_azure(cls, container_name: Optional[str] = None) -> "ModelStore":
         """Creates a ModelStore instance that stores models to an
         Azure blob container. This assumes that the container already exists."""
         if not AZURE_EXISTS:
@@ -63,7 +65,11 @@ class ModelStore:
         )
 
     @classmethod
-    def from_gcloud(cls, project_name: str, bucket_name: str) -> "ModelStore":
+    def from_gcloud(
+        cls,
+        project_name: Optional[str] = None,
+        bucket_name: Optional[str] = None,
+    ) -> "ModelStore":
         """Creates a ModelStore instance that stores models to a
         Google Cloud Bucket. This assumes that the Cloud bucket already exists."""
         if not GCLOUD_EXISTS:
@@ -73,7 +79,9 @@ class ModelStore:
         )
 
     @classmethod
-    def from_file_system(cls, root_directory: str) -> "ModelStore":
+    def from_file_system(
+        cls, root_directory: Optional[str] = None
+    ) -> "ModelStore":
         """Creates a ModelStore instance that stores models to
         the local file system."""
         return ModelStore(storage=FileSystemStorage(root_directory))

--- a/modelstore/storage/CONTRIBUTING.md
+++ b/modelstore/storage/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To add support for a new storage layer, add a new factory method in `modelstore.
 
 ```python
     @classmethod
-    def from_aws_s3(cls, bucket_name: str, region: str = None) -> "ModelStore":
+    def from_aws_s3(cls, bucket_name: Optional[str] = None, region: Optional[str] = None) -> "ModelStore":
         """Creates a ModelStore instance that stores models to an AWS s3
         bucket.
 
@@ -42,6 +42,8 @@ To add support for a new storage layer, add a new factory method in `modelstore.
             storage=AWSStorage(bucket_name=bucket_name, region=region)
         )
 ```
+
+Note that the arguments are all `Optional`. That is because `modelstore` enables retrieving these variables from the user's environment.
 
 ## Writing unit tests for the class you've added
 

--- a/modelstore/storage/aws.py
+++ b/modelstore/storage/aws.py
@@ -13,8 +13,10 @@
 #    limitations under the License.
 import json
 import os
+from typing import Optional
 
 from modelstore.storage.blob_storage import BlobStorage
+from modelstore.storage.util import environment
 from modelstore.storage.util.versions import sorted_by_created
 from modelstore.utils.log import logger
 
@@ -36,10 +38,16 @@ class AWSStorage(BlobStorage):
     https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html
     """
 
-    def __init__(self, bucket_name: str, region: str = None):
+    def __init__(
+        self, bucket_name: Optional[str], region: Optional[str] = None
+    ):
         super().__init__(["boto3"])
-        self.bucket_name = bucket_name
-        self.region = region
+        self.bucket_name = environment.get_value(
+            bucket_name, "MODEL_STORE_AWS_BUCKET"
+        )
+        self.region = environment.get_value(
+            region, "MODEL_STORE_REGION", allow_missing=True
+        )
         self.__client = None
 
     @property

--- a/modelstore/storage/aws.py
+++ b/modelstore/storage/aws.py
@@ -39,7 +39,7 @@ class AWSStorage(BlobStorage):
     """
 
     def __init__(
-        self, bucket_name: Optional[str], region: Optional[str] = None
+        self, bucket_name: Optional[str] = None, region: Optional[str] = None
     ):
         super().__init__(["boto3"])
         self.bucket_name = environment.get_value(

--- a/modelstore/storage/aws.py
+++ b/modelstore/storage/aws.py
@@ -38,6 +38,8 @@ class AWSStorage(BlobStorage):
     https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html
     """
 
+    NAME = "aws-s3"
+
     def __init__(
         self, bucket_name: Optional[str] = None, region: Optional[str] = None
     ):

--- a/modelstore/storage/aws.py
+++ b/modelstore/storage/aws.py
@@ -39,6 +39,14 @@ class AWSStorage(BlobStorage):
     """
 
     NAME = "aws-s3"
+    BUILD_FROM_ENVIRONMENT = {
+        "required": [
+            "MODEL_STORE_AWS_BUCKET",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+        ],
+        "optional": ["MODEL_STORE_REGION"],
+    }
 
     def __init__(
         self, bucket_name: Optional[str] = None, region: Optional[str] = None

--- a/modelstore/storage/azure.py
+++ b/modelstore/storage/azure.py
@@ -13,8 +13,10 @@
 #    limitations under the License.
 import json
 import os
+from typing import Optional
 
 from modelstore.storage.blob_storage import BlobStorage
+from modelstore.storage.util import environment
 from modelstore.storage.util.versions import sorted_by_created
 from modelstore.utils.log import logger
 
@@ -37,12 +39,14 @@ class AzureBlobStorage(BlobStorage):
 
     def __init__(
         self,
-        container_name: str,
+        container_name: Optional[str] = None,
         client: "azure.storage.blobage.BlobClient" = None,
         environ_key: str = "AZURE_STORAGE_CONNECTION_STRING",
     ):
         super().__init__(["azure.storage.blob"])
-        self.container_name = container_name
+        self.container_name = environment.get_value(
+            container_name, "MODEL_STORE_AZURE_CONTAINER"
+        )
         self.connection_string_key = environ_key
         self.__client = client
 

--- a/modelstore/storage/azure.py
+++ b/modelstore/storage/azure.py
@@ -37,6 +37,8 @@ class AzureBlobStorage(BlobStorage):
     and that the Azure Container already exists
     """
 
+    NAME = "azure-container"
+
     def __init__(
         self,
         container_name: Optional[str] = None,

--- a/modelstore/storage/azure.py
+++ b/modelstore/storage/azure.py
@@ -38,6 +38,15 @@ class AzureBlobStorage(BlobStorage):
     """
 
     NAME = "azure-container"
+    BUILD_FROM_ENVIRONMENT = {
+        "required": [
+            "MODEL_STORE_AZURE_CONTAINER",
+            "AZURE_ACCOUNT_NAME",
+            "AZURE_ACCESS_KEY",
+            "AZURE_STORAGE_CONNECTION_STRING",
+        ],
+        "optional": [],
+    }
 
     def __init__(
         self,

--- a/modelstore/storage/blob_storage.py
+++ b/modelstore/storage/blob_storage.py
@@ -148,6 +148,7 @@ class BlobStorage(CloudStorage):
             logger.info("Latest model is: %f", model_meta["model"]["model_id"])
         else:
             model_meta_path = self._get_metadata_path(domain, model_id)
+            # Note: this will fail if the model does not exist (needs a more informative exception)
             model_meta = self._read_json_object(model_meta_path)
         storage_path = self._get_storage_location(model_meta["storage"])
         return self._pull(storage_path, local_path)

--- a/modelstore/storage/gcloud.py
+++ b/modelstore/storage/gcloud.py
@@ -13,8 +13,10 @@
 #    limitations under the License.
 import json
 import os
+from typing import Optional
 
 from modelstore.storage.blob_storage import BlobStorage
+from modelstore.storage.util import environment
 from modelstore.storage.util.versions import sorted_by_created
 from modelstore.utils.log import logger
 
@@ -42,13 +44,17 @@ class GoogleCloudStorage(BlobStorage):
 
     def __init__(
         self,
-        project_name: str,
-        bucket_name: str,
+        project_name: Optional[str],
+        bucket_name: Optional[str],
         client: "storage.Client" = None,
     ):
         super().__init__(["google.cloud.storage"])
-        self.project_name = project_name
-        self.bucket_name = bucket_name
+        self.project_name = environment.get_value(
+            project_name, "MODEL_STORE_GCP_PROJECT"
+        )
+        self.bucket_name = environment.get_value(
+            bucket_name, "MODEL_STORE_GCP_BUCKET"
+        )
         self.__client = client
 
     @property

--- a/modelstore/storage/gcloud.py
+++ b/modelstore/storage/gcloud.py
@@ -42,6 +42,8 @@ class GoogleCloudStorage(BlobStorage):
     Assumes that google.cloud.storage is installed and configured
     """
 
+    NAME = "google-cloud-storage"
+
     def __init__(
         self,
         project_name: Optional[str] = None,

--- a/modelstore/storage/gcloud.py
+++ b/modelstore/storage/gcloud.py
@@ -44,8 +44,8 @@ class GoogleCloudStorage(BlobStorage):
 
     def __init__(
         self,
-        project_name: Optional[str],
-        bucket_name: Optional[str],
+        project_name: Optional[str] = None,
+        bucket_name: Optional[str] = None,
         client: "storage.Client" = None,
     ):
         super().__init__(["google.cloud.storage"])

--- a/modelstore/storage/gcloud.py
+++ b/modelstore/storage/gcloud.py
@@ -43,6 +43,10 @@ class GoogleCloudStorage(BlobStorage):
     """
 
     NAME = "google-cloud-storage"
+    BUILD_FROM_ENVIRONMENT = {
+        "required": ["MODEL_STORE_GCP_PROJECT", "MODEL_STORE_GCP_BUCKET"],
+        "optional": [],
+    }
 
     def __init__(
         self,

--- a/modelstore/storage/hosted.py
+++ b/modelstore/storage/hosted.py
@@ -34,6 +34,10 @@ class HostedStorage(CloudStorage):
     """
 
     NAME = "hosted"
+    BUILD_FROM_ENVIRONMENT = {
+        "required": ["MODELSTORE_KEY_ID", "MODELSTORE_ACCESS_KEY"],
+        "optional": [],
+    }
 
     def __init__(
         self, access_key_id: Optional[str], secret_access_key: Optional[str]

--- a/modelstore/storage/hosted.py
+++ b/modelstore/storage/hosted.py
@@ -33,6 +33,8 @@ class HostedStorage(CloudStorage):
     Usage of this storage requires you to have an `api_access_key` and `api_key_id`.
     """
 
+    NAME = "hosted"
+
     def __init__(
         self, access_key_id: Optional[str], secret_access_key: Optional[str]
     ):

--- a/modelstore/storage/local.py
+++ b/modelstore/storage/local.py
@@ -20,11 +20,9 @@ from typing import Optional
 
 from modelstore.storage.blob_storage import BlobStorage
 from modelstore.storage.util import environment
-from modelstore.storage.util.paths import (
-    MODELSTORE_ROOT,
-    get_model_state_path,
-    is_valid_state_name,
-)
+from modelstore.storage.util.paths import (MODELSTORE_ROOT,
+                                           get_model_state_path,
+                                           is_valid_state_name)
 from modelstore.storage.util.versions import sorted_by_created
 from modelstore.utils.log import logger
 
@@ -34,6 +32,8 @@ class FileSystemStorage(BlobStorage):
     """
     File System Storage
     """
+
+    NAME = "filesystem"
 
     def __init__(self, root_path: Optional[str] = None):
         super().__init__([])

--- a/modelstore/storage/local.py
+++ b/modelstore/storage/local.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Optional
 
 from modelstore.storage.blob_storage import BlobStorage
+from modelstore.storage.util import environment
 from modelstore.storage.util.paths import (
     MODELSTORE_ROOT,
     get_model_state_path,
@@ -34,8 +35,9 @@ class FileSystemStorage(BlobStorage):
     File System Storage
     """
 
-    def __init__(self, root_path: str):
+    def __init__(self, root_path: Optional[str] = None):
         super().__init__([])
+        root_path = environment.get_value(root_path, "MODEL_STORE_ROOT")
         if MODELSTORE_ROOT in root_path:
             warnings.warn(
                 f'Warning: "{MODELSTORE_ROOT}" is in the root path, and is a value'

--- a/modelstore/storage/local.py
+++ b/modelstore/storage/local.py
@@ -20,9 +20,11 @@ from typing import Optional
 
 from modelstore.storage.blob_storage import BlobStorage
 from modelstore.storage.util import environment
-from modelstore.storage.util.paths import (MODELSTORE_ROOT,
-                                           get_model_state_path,
-                                           is_valid_state_name)
+from modelstore.storage.util.paths import (
+    MODELSTORE_ROOT,
+    get_model_state_path,
+    is_valid_state_name,
+)
 from modelstore.storage.util.versions import sorted_by_created
 from modelstore.utils.log import logger
 
@@ -30,10 +32,16 @@ from modelstore.utils.log import logger
 class FileSystemStorage(BlobStorage):
 
     """
-    File System Storage
+    File System Storage: store models in a directory
     """
 
     NAME = "filesystem"
+    BUILD_FROM_ENVIRONMENT = {
+        "required": [
+            "MODEL_STORE_ROOT",
+        ],
+        "optional": [],
+    }
 
     def __init__(self, root_path: Optional[str] = None):
         super().__init__([])

--- a/modelstore/storage/util/environment.py
+++ b/modelstore/storage/util/environment.py
@@ -1,9 +1,23 @@
 import os
+from typing import Optional
 
 
-def get_value(arg: str, env_key: str, allow_missing: bool = False) -> str:
+def get_value(
+    arg: str, env_key: str, allow_missing: bool = False
+) -> Optional[str]:
+    """Modelstore storage can optionally be instantiated using
+    environment variables. This function is used to decide whether to
+    - pull a variable from the user's environment;
+    - return the one that was passed in;
+    - return None
+    """
     if arg is not None:
+        # arg has been passed in as non-None, so return it
         return arg
     if env_key not in os.environ and allow_missing:
+        # The environment key doesn't exist for a variable that
+        # is allowed to be missing, so return None
         return None
+    # Return the environment variable; this will KeyError if it
+    # is missing
     return os.environ[env_key]

--- a/modelstore/storage/util/environment.py
+++ b/modelstore/storage/util/environment.py
@@ -1,5 +1,32 @@
+#    Copyright 2021 Neal Lathia
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
 import os
 from typing import Optional
+
+import modelstore.utils.cli as modelstorecli
+from modelstore.model_store import ModelStore
+from modelstore.storage.aws import AWSStorage
+from modelstore.storage.gcloud import GoogleCloudStorage
+from modelstore.storage.hosted import HostedStorage
+from modelstore.storage.local import FileSystemStorage
+
+STORAGE_TYPES = {
+    AWSStorage.NAME: AWSStorage,
+    GoogleCloudStorage.NAME: GoogleCloudStorage,
+    HostedStorage.NAME: HostedStorage,
+    FileSystemStorage.NAME: FileSystemStorage,
+}
 
 
 def get_value(
@@ -21,3 +48,14 @@ def get_value(
     # Return the environment variable; this will KeyError if it
     # is missing
     return os.environ[env_key]
+
+
+def model_store_from_env() -> ModelStore:
+    """Used by the modelstore CLI to construct a ModelStore
+    instance purely using environment variables
+    """
+    storage_name = os.environ["MODEL_STORE_STORAGE"]
+    if storage_name not in STORAGE_TYPES:
+        raise ValueError(f"Unknown storage name: {storage_name}")
+    modelstorecli.info(f"Using: {storage_name} model store.")
+    return STORAGE_TYPES[storage_name]()

--- a/modelstore/storage/util/environment.py
+++ b/modelstore/storage/util/environment.py
@@ -1,0 +1,9 @@
+import os
+
+
+def get_value(arg: str, env_key: str, allow_missing: bool = False) -> str:
+    if arg is not None:
+        return arg
+    if env_key not in os.environ and allow_missing:
+        return None
+    return os.environ[env_key]

--- a/modelstore/storage/util/environment.py
+++ b/modelstore/storage/util/environment.py
@@ -14,20 +14,6 @@
 import os
 from typing import Optional
 
-import modelstore.utils.cli as modelstorecli
-from modelstore.model_store import ModelStore
-from modelstore.storage.aws import AWSStorage
-from modelstore.storage.gcloud import GoogleCloudStorage
-from modelstore.storage.hosted import HostedStorage
-from modelstore.storage.local import FileSystemStorage
-
-STORAGE_TYPES = {
-    AWSStorage.NAME: AWSStorage,
-    GoogleCloudStorage.NAME: GoogleCloudStorage,
-    HostedStorage.NAME: HostedStorage,
-    FileSystemStorage.NAME: FileSystemStorage,
-}
-
 
 def get_value(
     arg: str, env_key: str, allow_missing: bool = False
@@ -48,14 +34,3 @@ def get_value(
     # Return the environment variable; this will KeyError if it
     # is missing
     return os.environ[env_key]
-
-
-def model_store_from_env() -> ModelStore:
-    """Used by the modelstore CLI to construct a ModelStore
-    instance purely using environment variables
-    """
-    storage_name = os.environ["MODEL_STORE_STORAGE"]
-    if storage_name not in STORAGE_TYPES:
-        raise ValueError(f"Unknown storage name: {storage_name}")
-    modelstorecli.info(f"Using: {storage_name} model store.")
-    return STORAGE_TYPES[storage_name]()

--- a/modelstore/utils/cli.py
+++ b/modelstore/utils/cli.py
@@ -1,0 +1,75 @@
+import os
+import sys
+from enum import Enum
+from typing import Optional
+
+import click
+from modelstore import ModelStore
+
+
+class MessageStatus(Enum):
+
+    """
+    MessageStatus enumerates the different potential statuses
+    that we can print messages about in the CLI, and their
+    associated color
+    """
+
+    Sucess: str = "green"
+    Failure: str = "red"
+    Info: str = "blue"
+
+
+def echo(message: str, status: MessageStatus):
+    click.echo(click.style(message, fg=status.value))
+
+
+def success(message: str):
+    echo(message, MessageStatus.Sucess)
+
+
+def failure(message: str):
+    echo(message, MessageStatus.Failure)
+
+
+def info(message: str):
+    echo(message, MessageStatus.Info)
+
+
+def assert_environ_exists(
+    storage_type: str, keys: list, optional_keys: Optional[list]
+):
+    missing_required_keys = [k for k in keys if k not in os.environ]
+    if len(missing_required_keys) != 0:
+        missing_optional_keys = [
+            k for k in optional_keys if k not in os.environ
+        ]
+        failure(
+            f"❌ Failed to create {storage_type} modelstore.\nYour environment is missing:"
+        )
+        for k in missing_required_keys:
+            failure(f"- {k} (required)")
+        for k in missing_optional_keys:
+            failure(f"- {k} (optional)")
+        sys.exit(1)
+
+
+def model_store_from_env() -> ModelStore:
+    storage_type = os.environ["MODEL_STORE_STORAGE"]
+    if storage_type == "aws":
+        assert_environ_exists(
+            "aws", ["MODEL_STORE_AWS_BUCKET"], ["MODEL_STORE_REGION"]
+        )
+        return ModelStore.from_aws_s3()
+    if storage_type == "gcloud":
+        assert_environ_exists(
+            "aws", ["MODEL_STORE_GCP_PROJECT", "MODEL_STORE_GCP_BUCKET"], []
+        )
+        return ModelStore.from_gcloud()
+    if storage_type == "azure":
+        assert_environ_exists("aws", ["MODEL_STORE_AZURE_CONTAINER"], [])
+        return ModelStore.from_azure()
+    if storage_type == "filesystem":
+        assert_environ_exists("aws", ["MODEL_STORE_ROOT"], [])
+        return ModelStore.from_file_system()
+    raise ValueError(f"Uknown modelstore type: {storage_type}")

--- a/modelstore/utils/cli.py
+++ b/modelstore/utils/cli.py
@@ -65,6 +65,10 @@ def assert_environ_exists(storage_type: str, keys: dict):
 
 
 def model_store_from_env() -> ModelStore:
+    if "MODEL_STORE_STORAGE" not in os.environ:
+        failure("❌  No value for MODEL_STORE_STORAGE set in os.environ")
+        sys.exit(1)
+
     storage_name = os.environ["MODEL_STORE_STORAGE"]
     if storage_name not in STORAGE_TYPES:
         failure(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ joblib>=1.0.0
 onnxruntime>=1.6.0
 requests>=2.23.0
 tqdm>=4.54.1
+click>=8.0.3

--- a/tests/storage/test_aws.py
+++ b/tests/storage/test_aws.py
@@ -49,6 +49,7 @@ def aws_model_store():
 
 
 def test_create_from_environment_variables():
+    # Does not fail when environment variables exist
     with mock.patch.dict(
         os.environ, {"MODEL_STORE_AWS_BUCKET": _MOCK_BUCKET_NAME}
     ):
@@ -57,6 +58,9 @@ def test_create_from_environment_variables():
             _ = AWSStorage()
         except:
             pytest.fail("Failed to initialise storage from env variables")
+    # Fails when environment variables are missing
+    with pytest.raises(KeyError):
+        _ = AWSStorage()
 
 
 def test_validate_existing_bucket(aws_model_store):

--- a/tests/storage/test_aws.py
+++ b/tests/storage/test_aws.py
@@ -15,6 +15,7 @@ import json
 import os
 
 import boto3
+import mock
 import pytest
 from modelstore.storage.aws import AWSStorage
 from moto import mock_s3
@@ -45,6 +46,17 @@ def moto_boto():
 @pytest.fixture
 def aws_model_store():
     return AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
+
+
+def test_create_from_environment_variables():
+    with mock.patch.dict(
+        os.environ, {"MODEL_STORE_AWS_BUCKET": _MOCK_BUCKET_NAME}
+    ):
+        # pylint: disable=bare-except
+        try:
+            _ = AWSStorage()
+        except:
+            pytest.fail("Failed to initialise storage from env variables")
 
 
 def test_validate_existing_bucket(aws_model_store):

--- a/tests/storage/test_azure.py
+++ b/tests/storage/test_azure.py
@@ -78,6 +78,7 @@ def azure_storage(azure_client):
 
 
 def test_create_from_environment_variables():
+    # Does not fail when environment variables exist
     with mock.patch.dict(
         os.environ, {"MODEL_STORE_AZURE_CONTAINER": _MOCK_CONTAINER_NAME}
     ):
@@ -86,6 +87,9 @@ def test_create_from_environment_variables():
             _ = AzureBlobStorage()
         except:
             pytest.fail("Failed to initialise storage from env variables")
+    # Fails when environment variables are missing
+    with pytest.raises(KeyError):
+        _ = AzureBlobStorage()
 
 
 def test_validate_existing_container(azure_storage):

--- a/tests/storage/test_azure.py
+++ b/tests/storage/test_azure.py
@@ -77,6 +77,17 @@ def azure_storage(azure_client):
     )
 
 
+def test_create_from_environment_variables():
+    with mock.patch.dict(
+        os.environ, {"MODEL_STORE_AZURE_CONTAINER": _MOCK_CONTAINER_NAME}
+    ):
+        # pylint: disable=bare-except
+        try:
+            _ = AzureBlobStorage()
+        except:
+            pytest.fail("Failed to initialise storage from env variables")
+
+
 def test_validate_existing_container(azure_storage):
     assert azure_storage.validate()
 

--- a/tests/storage/test_gcloud.py
+++ b/tests/storage/test_gcloud.py
@@ -65,6 +65,21 @@ def gcloud_model_store(gcloud_client):
     )
 
 
+def test_create_from_environment_variables():
+    with mock.patch.dict(
+        os.environ,
+        {
+            "MODEL_STORE_GCP_PROJECT": "project",
+            "MODEL_STORE_GCP_BUCKET": _MOCK_BUCKET_NAME,
+        },
+    ):
+        # pylint: disable=bare-except
+        try:
+            _ = GoogleCloudStorage()
+        except:
+            pytest.fail("Failed to initialise storage from env variables")
+
+
 def test_validate_existing_bucket(gcloud_model_store):
     assert gcloud_model_store.validate()
 

--- a/tests/storage/test_gcloud.py
+++ b/tests/storage/test_gcloud.py
@@ -66,6 +66,7 @@ def gcloud_model_store(gcloud_client):
 
 
 def test_create_from_environment_variables():
+    # Does not fail when environment variables exist
     with mock.patch.dict(
         os.environ,
         {
@@ -78,6 +79,9 @@ def test_create_from_environment_variables():
             _ = GoogleCloudStorage()
         except:
             pytest.fail("Failed to initialise storage from env variables")
+    # Fails when environment variables are missing
+    with pytest.raises(KeyError):
+        _ = GoogleCloudStorage()
 
 
 def test_validate_existing_bucket(gcloud_model_store):

--- a/tests/storage/test_local.py
+++ b/tests/storage/test_local.py
@@ -38,6 +38,7 @@ def fs_model_store(tmp_path):
 
 
 def test_create_from_environment_variables():
+    # Does not fail when environment variables exist
     with mock.patch.dict(
         os.environ,
         {
@@ -49,6 +50,9 @@ def test_create_from_environment_variables():
             _ = FileSystemStorage()
         except:
             pytest.fail("Failed to initialise storage from env variables")
+    # Fails when environment variables are missing
+    with pytest.raises(KeyError):
+        _ = FileSystemStorage()
 
 
 def test_validate(fs_model_store):

--- a/tests/storage/test_local.py
+++ b/tests/storage/test_local.py
@@ -14,6 +14,7 @@
 import json
 import os
 
+import mock
 import pytest
 from modelstore.storage.local import FileSystemStorage
 
@@ -34,6 +35,20 @@ from tests.storage.test_utils import (
 @pytest.fixture
 def fs_model_store(tmp_path):
     return FileSystemStorage(root_path=str(tmp_path))
+
+
+def test_create_from_environment_variables():
+    with mock.patch.dict(
+        os.environ,
+        {
+            "MODEL_STORE_ROOT": "~",
+        },
+    ):
+        # pylint: disable=bare-except
+        try:
+            _ = FileSystemStorage()
+        except:
+            pytest.fail("Failed to initialise storage from env variables")
 
 
 def test_validate(fs_model_store):


### PR DESCRIPTION
Enables CLI usage of `modelstore`:

```
❯ python -m modelstore <domain> <model-id> <target-directory>
```