### PR TITLE
Fix git ImportError issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
-🆕   Added CLI functionality! You can now `python -m modelstore download <domain> <model-id> <directory>` to download a model. This requires you to set environment variables.
+🐛  Fixed an `ImportError` bug when trying to use `modelstore` on an instance [that does not have git installed](https://github.com/operatorai/modelstore/pull/86).
 
-📈  Added [Prophet](https://facebook.github.io/prophet/) support
+🆕   Added CLI functionality! You can now `python -m modelstore download <domain> <model-id> <directory>` to download a model. This requires you to [set environment variables](https://modelstore.readthedocs.io/en/latest/concepts/cli.html).
+
+🆕  Added [Prophet](https://facebook.github.io/prophet/) support.
 
 🆕 Need to upload additional files alongside your model? You can now use the extras= kwarg in modelstore.upload() to point modelstore to a file (or list of files) to upload as well.
 
@@ -74,10 +76,10 @@
 
 ## modelstore 0.0.1b
 
-First release! Supports (and tested on) Python 3.7 only. ☢️
+🆕  First release! Supports (and tested on) Python 3.7 only. ☢️
 
-Storage: GCP buckets, AWS S3 buckets, file systems. Upload only!
+🆕  Storage: GCP buckets, AWS S3 buckets, file systems. Upload only!
 
-Initial models: `catboost`, `keras`, `torch`, `sklearn`, `xgboost`
+🆕  Initial models: `catboost`, `keras`, `torch`, `sklearn`, `xgboost`
 
-Meta-data: Python runtime, user, dependency versions, git hash
+🆕  Meta-data: Python runtime, user, dependency versions, git hash

--- a/modelstore/__init__.py
+++ b/modelstore/__init__.py
@@ -1,5 +1,8 @@
-from pkg_resources import get_distribution
+from pkg_resources import DistributionNotFound, get_distribution
 
 from modelstore.model_store import ModelStore
 
-__version__ = get_distribution("modelstore").version
+try:
+    __version__ = get_distribution("modelstore").version
+except DistributionNotFound:
+    __version__ = "unavailable"

--- a/modelstore/meta/revision.py
+++ b/modelstore/meta/revision.py
@@ -1,9 +1,18 @@
-import git
+from modelstore.utils.log import logger
 
-# pylint: disable=broad-except
+try:
+    import git
+
+    GIT_EXISTS = True
+except ImportError:
+    logger.info("Warning: no git installation. Will not collect git meta data.")
+    GIT_EXISTS = False
 
 
-def _repo_name(repo: git.Repo) -> str:
+def _repo_name(repo: "git.Repo") -> str:
+    if not GIT_EXISTS:
+        return ""
+    # pylint: disable=broad-except
     try:
         repo_url = repo.remotes.origin.url
         return repo_url.split(".git")[0].split("/")[-1]
@@ -12,6 +21,9 @@ def _repo_name(repo: git.Repo) -> str:
 
 
 def git_meta() -> dict:
+    if not GIT_EXISTS:
+        return {}
+    # pylint: disable=broad-except
     try:
         repo = git.Repo(search_parent_directories=True)
         return {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dataclasses==0.8; python_version < '3.7'
 gitpython>=3.1.11
 joblib>=1.0.0
-onnxruntime>=1.6.0
+onnxruntime>=1.3.0
 requests>=2.23.0
 tqdm>=4.54.1
 click>=8.0.3

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 from setuptools import find_packages, setup
 
-with open("README.md", "r") as lines:
-    long_description = lines.read()
-
 with open("requirements.txt", "r") as lines:
     requirements = lines.read().splitlines()
 
@@ -12,7 +9,7 @@ setup(
     packages=find_packages(exclude=["tests", "examples", "docs"]),
     include_package_data=True,
     description="modelstore is a library for versioning, exporting, storing, and loading machine learning models",
-    long_description=long_description,
+    long_description="Please refer to: https://modelstore.readthedocs.io/en/latest/",
     long_description_content_type="text/markdown",
     url="https://github.com/operatorai/modelstore",
     author="Neal Lathia",

--- a/tests/storage/test_aws.py
+++ b/tests/storage/test_aws.py
@@ -48,7 +48,7 @@ def aws_model_store():
     return AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
 
 
-def test_create_from_environment_variables():
+def test_create_from_environment_variables(monkeypatch):
     # Does not fail when environment variables exist
     with mock.patch.dict(
         os.environ, {"MODEL_STORE_AWS_BUCKET": _MOCK_BUCKET_NAME}
@@ -59,6 +59,8 @@ def test_create_from_environment_variables():
         except:
             pytest.fail("Failed to initialise storage from env variables")
     # Fails when environment variables are missing
+    for key in AWSStorage.BUILD_FROM_ENVIRONMENT.get("required", []):
+        monkeypatch.delenv(key)
     with pytest.raises(KeyError):
         _ = AWSStorage()
 

--- a/tests/storage/test_aws.py
+++ b/tests/storage/test_aws.py
@@ -19,16 +19,10 @@ import mock
 import pytest
 from modelstore.storage.aws import AWSStorage
 from moto import mock_s3
-
 # pylint: disable=unused-import
-from tests.storage.test_utils import (
-    TEST_FILE_CONTENTS,
-    TEST_FILE_NAME,
-    file_contains_expected_contents,
-    remote_file_path,
-    remote_path,
-    temp_file,
-)
+from tests.storage.test_utils import (TEST_FILE_CONTENTS, TEST_FILE_NAME,
+                                      file_contains_expected_contents,
+                                      remote_file_path, remote_path, temp_file)
 
 # pylint: disable=redefined-outer-name
 # pylint: disable=protected-access
@@ -60,7 +54,7 @@ def test_create_from_environment_variables(monkeypatch):
             pytest.fail("Failed to initialise storage from env variables")
     # Fails when environment variables are missing
     for key in AWSStorage.BUILD_FROM_ENVIRONMENT.get("required", []):
-        monkeypatch.delenv(key)
+        monkeypatch.delenv(key, raising=False)
     with pytest.raises(KeyError):
         _ = AWSStorage()
 

--- a/tests/storage/test_azure.py
+++ b/tests/storage/test_azure.py
@@ -16,15 +16,9 @@ import os
 from unittest import mock
 
 import pytest
-from azure.storage.blob import (
-    BlobClient,
-    BlobProperties,
-    BlobServiceClient,
-    ContainerClient,
-    StorageStreamDownloader,
-)
+from azure.storage.blob import (BlobClient, BlobProperties, BlobServiceClient,
+                                ContainerClient, StorageStreamDownloader)
 from modelstore.storage.azure import AzureBlobStorage
-
 # pylint: disable=unused-import
 from tests.storage.test_utils import temp_file
 
@@ -89,7 +83,7 @@ def test_create_from_environment_variables(monkeypatch):
             pytest.fail("Failed to initialise storage from env variables")
     # Fails when environment variables are missing
     for key in AzureBlobStorage.BUILD_FROM_ENVIRONMENT.get("required", []):
-        monkeypatch.delenv(key)
+        monkeypatch.delenv(key, raising=False)
     with pytest.raises(KeyError):
         _ = AzureBlobStorage()
 

--- a/tests/storage/test_azure.py
+++ b/tests/storage/test_azure.py
@@ -77,7 +77,7 @@ def azure_storage(azure_client):
     )
 
 
-def test_create_from_environment_variables():
+def test_create_from_environment_variables(monkeypatch):
     # Does not fail when environment variables exist
     with mock.patch.dict(
         os.environ, {"MODEL_STORE_AZURE_CONTAINER": _MOCK_CONTAINER_NAME}
@@ -88,6 +88,8 @@ def test_create_from_environment_variables():
         except:
             pytest.fail("Failed to initialise storage from env variables")
     # Fails when environment variables are missing
+    for key in AzureBlobStorage.BUILD_FROM_ENVIRONMENT.get("required", []):
+        monkeypatch.delenv(key)
     with pytest.raises(KeyError):
         _ = AzureBlobStorage()
 

--- a/tests/storage/test_gcloud.py
+++ b/tests/storage/test_gcloud.py
@@ -65,7 +65,7 @@ def gcloud_model_store(gcloud_client):
     )
 
 
-def test_create_from_environment_variables():
+def test_create_from_environment_variables(monkeypatch):
     # Does not fail when environment variables exist
     with mock.patch.dict(
         os.environ,
@@ -80,6 +80,8 @@ def test_create_from_environment_variables():
         except:
             pytest.fail("Failed to initialise storage from env variables")
     # Fails when environment variables are missing
+    for key in GoogleCloudStorage.BUILD_FROM_ENVIRONMENT.get("required", []):
+        monkeypatch.delenv(key)
     with pytest.raises(KeyError):
         _ = GoogleCloudStorage()
 

--- a/tests/storage/test_gcloud.py
+++ b/tests/storage/test_gcloud.py
@@ -81,7 +81,7 @@ def test_create_from_environment_variables(monkeypatch):
             pytest.fail("Failed to initialise storage from env variables")
     # Fails when environment variables are missing
     for key in GoogleCloudStorage.BUILD_FROM_ENVIRONMENT.get("required", []):
-        monkeypatch.delenv(key)
+        monkeypatch.delenv(key, raising=False)
     with pytest.raises(KeyError):
         _ = GoogleCloudStorage()
 

--- a/tests/storage/test_local.py
+++ b/tests/storage/test_local.py
@@ -16,7 +16,6 @@ import os
 
 import mock
 import pytest
-from _pytest.python_api import raises
 from modelstore.storage.local import FileSystemStorage
 
 # pylint: disable=unused-import

--- a/tests/storage/test_local.py
+++ b/tests/storage/test_local.py
@@ -53,7 +53,7 @@ def test_create_from_environment_variables(monkeypatch):
 
     # Fails when environment variables are missing
     for key in FileSystemStorage.BUILD_FROM_ENVIRONMENT.get("required", []):
-        monkeypatch.delenv(key)
+        monkeypatch.delenv(key, raising=False)
     with pytest.raises(KeyError):
         _ = FileSystemStorage()
 

--- a/tests/storage/test_local.py
+++ b/tests/storage/test_local.py
@@ -16,6 +16,7 @@ import os
 
 import mock
 import pytest
+from _pytest.python_api import raises
 from modelstore.storage.local import FileSystemStorage
 
 # pylint: disable=unused-import
@@ -37,7 +38,7 @@ def fs_model_store(tmp_path):
     return FileSystemStorage(root_path=str(tmp_path))
 
 
-def test_create_from_environment_variables():
+def test_create_from_environment_variables(monkeypatch):
     # Does not fail when environment variables exist
     with mock.patch.dict(
         os.environ,
@@ -50,7 +51,10 @@ def test_create_from_environment_variables():
             _ = FileSystemStorage()
         except:
             pytest.fail("Failed to initialise storage from env variables")
+
     # Fails when environment variables are missing
+    for key in FileSystemStorage.BUILD_FROM_ENVIRONMENT.get("required", []):
+        monkeypatch.delenv(key)
     with pytest.raises(KeyError):
         _ = FileSystemStorage()
 


### PR DESCRIPTION
An exception would be raised when running:

```
from modelstore import ModelStore
```

On an instance that does not have `git` installed (even though the python git library is installed). This is because the python library only checks for a `git` installation when `import git` is run. This PR defends against that exception being raised