### PR TITLE
Adds the ability to set a root_dir for AWS buckets

### DIFF
--- a/examples/examples-by-ml-library/modelstores.py
+++ b/examples/examples-by-ml-library/modelstores.py
@@ -17,7 +17,10 @@ def create_aws_model_store() -> ModelStore:
     # A model store in an AWS S3 bucket
     # The modelstore library assumes you have already created
     # an s3 bucket and will raise an exception if it doesn't exist
-    return ModelStore.from_aws_s3(os.environ["MODEL_STORE_AWS_BUCKET"])
+    return ModelStore.from_aws_s3(
+        os.environ["MODEL_STORE_AWS_BUCKET"],
+        model_store_root="example-by-ml-library",
+    )
 
 
 def create_azure_model_store() -> ModelStore:
@@ -35,8 +38,7 @@ def create_gcloud_model_store() -> ModelStore:
     # The modelstore library assumes you have already created
     # a Cloud Storage bucket and will raise an exception if it doesn't exist
     return ModelStore.from_gcloud(
-        os.environ["MODEL_STORE_GCP_PROJECT"],
-        os.environ["MODEL_STORE_GCP_BUCKET"],
+        os.environ["MODEL_STORE_GCP_PROJECT"], os.environ["MODEL_STORE_GCP_BUCKET"],
     )
 
 

--- a/examples/examples-by-ml-library/modelstores.py
+++ b/examples/examples-by-ml-library/modelstores.py
@@ -19,7 +19,7 @@ def create_aws_model_store() -> ModelStore:
     # an s3 bucket and will raise an exception if it doesn't exist
     return ModelStore.from_aws_s3(
         os.environ["MODEL_STORE_AWS_BUCKET"],
-        model_store_root="example-by-ml-library",
+        root_dir="example-by-ml-library",
     )
 
 

--- a/examples/examples-by-ml-library/modelstores.py
+++ b/examples/examples-by-ml-library/modelstores.py
@@ -46,5 +46,5 @@ def create_file_system_model_store() -> ModelStore:
     # A model store in a local file system
     # Here, we create a new local model store in our home directory
     home_dir = os.path.expanduser("~")
-    print(f"🏦  Creating store in: {home_dir}")
-    return ModelStore.from_file_system(root_directory=home_dir)
+    print(f"🏦  Creating store in: {home_dir}" +"/test-modelstore")
+    return ModelStore.from_file_system(root_directory=home_dir+"/test-modelstore")

--- a/examples/examples-by-storage/modelstores.py
+++ b/examples/examples-by-storage/modelstores.py
@@ -17,7 +17,7 @@ def create_aws_model_store() -> ModelStore:
     # A model store in an AWS S3 bucket
     # The modelstore library assumes you have already created
     # an s3 bucket and will raise an exception if it doesn't exist
-    return ModelStore.from_aws_s3(os.environ["MODEL_STORE_AWS_BUCKET"])
+    return ModelStore.from_aws_s3(os.environ["MODEL_STORE_AWS_BUCKET"], root_dir='example-by-ml-library')
 
 
 def create_azure_model_store() -> ModelStore:

--- a/modelstore/model_store.py
+++ b/modelstore/model_store.py
@@ -42,7 +42,7 @@ class ModelStore:
 
     @classmethod
     def from_aws_s3(
-        cls, bucket_name: Optional[str] = None, region: Optional[str] = None,  model_store_root: Optional[str]=None,
+        cls, bucket_name: Optional[str] = None, region: Optional[str] = None,  root_dir: Optional[str]=None,
     ) -> "ModelStore":
         """Creates a ModelStore instance that stores models to an AWS s3
         bucket.
@@ -51,7 +51,7 @@ class ModelStore:
         if not BOTO_EXISTS:
             raise ModuleNotFoundError("boto3 is not installed!")
         return ModelStore(
-            storage=AWSStorage(bucket_name=bucket_name, region=region, model_store_root=model_store_root)
+            storage=AWSStorage(bucket_name=bucket_name, region=region, root_dir=root_dir)
         )
 
     @classmethod

--- a/modelstore/model_store.py
+++ b/modelstore/model_store.py
@@ -42,7 +42,7 @@ class ModelStore:
 
     @classmethod
     def from_aws_s3(
-        cls, bucket_name: Optional[str] = None, region: Optional[str] = None
+        cls, bucket_name: Optional[str] = None, region: Optional[str] = None,  model_store_root: Optional[str]=None,
     ) -> "ModelStore":
         """Creates a ModelStore instance that stores models to an AWS s3
         bucket.
@@ -51,7 +51,7 @@ class ModelStore:
         if not BOTO_EXISTS:
             raise ModuleNotFoundError("boto3 is not installed!")
         return ModelStore(
-            storage=AWSStorage(bucket_name=bucket_name, region=region)
+            storage=AWSStorage(bucket_name=bucket_name, region=region, model_store_root=model_store_root)
         )
 
     @classmethod

--- a/modelstore/storage/aws.py
+++ b/modelstore/storage/aws.py
@@ -49,7 +49,7 @@ class AWSStorage(BlobStorage):
     }
 
     def __init__(
-        self, bucket_name: Optional[str] = None, region: Optional[str] = None
+        self, bucket_name: Optional[str] = None, region: Optional[str] = None,  model_store_root:  Optional[str] = None
     ):
         super().__init__(["boto3"])
         self.bucket_name = environment.get_value(
@@ -59,6 +59,7 @@ class AWSStorage(BlobStorage):
             region, "MODEL_STORE_REGION", allow_missing=True
         )
         self.__client = None
+        self.model_store_root = model_store_root if not None else ""
 
     @property
     def client(self):

--- a/modelstore/storage/aws.py
+++ b/modelstore/storage/aws.py
@@ -49,7 +49,7 @@ class AWSStorage(BlobStorage):
     }
 
     def __init__(
-        self, bucket_name: Optional[str] = None, region: Optional[str] = None,  model_store_root:  Optional[str] = None
+        self, bucket_name: Optional[str] = None, region: Optional[str] = None,  root_dir:  Optional[str] = None
     ):
         super().__init__(["boto3"])
         self.bucket_name = environment.get_value(
@@ -59,7 +59,7 @@ class AWSStorage(BlobStorage):
             region, "MODEL_STORE_REGION", allow_missing=True
         )
         self.__client = None
-        self.model_store_root = model_store_root if model_store_root is not None else ""
+        self.root_dir = root_dir if root_dir is not None else ""
         
 
     @property

--- a/modelstore/storage/aws.py
+++ b/modelstore/storage/aws.py
@@ -59,7 +59,8 @@ class AWSStorage(BlobStorage):
             region, "MODEL_STORE_REGION", allow_missing=True
         )
         self.__client = None
-        self.model_store_root = model_store_root if not None else ""
+        self.model_store_root = model_store_root if model_store_root is not None else ""
+        
 
     @property
     def client(self):

--- a/modelstore/storage/azure.py
+++ b/modelstore/storage/azure.py
@@ -53,7 +53,6 @@ class AzureBlobStorage(BlobStorage):
         container_name: Optional[str] = None,
         client: "azure.storage.blobage.BlobClient" = None,
         environ_key: str = "AZURE_STORAGE_CONNECTION_STRING",
-        model_store_root:  Optional[str] = None,
     ):
         super().__init__(["azure.storage.blob"])
         self.container_name = environment.get_value(
@@ -61,7 +60,7 @@ class AzureBlobStorage(BlobStorage):
         )
         self.connection_string_key = environ_key
         self.__client = client
-        self.model_store_root = model_store_root if not None else ""
+        self.model_store_root = ""
 
     @property
     def client(self) -> "azure.storage.blobage.BlobClient":

--- a/modelstore/storage/azure.py
+++ b/modelstore/storage/azure.py
@@ -53,6 +53,7 @@ class AzureBlobStorage(BlobStorage):
         container_name: Optional[str] = None,
         client: "azure.storage.blobage.BlobClient" = None,
         environ_key: str = "AZURE_STORAGE_CONNECTION_STRING",
+        model_store_root:  Optional[str] = None,
     ):
         super().__init__(["azure.storage.blob"])
         self.container_name = environment.get_value(
@@ -60,6 +61,7 @@ class AzureBlobStorage(BlobStorage):
         )
         self.connection_string_key = environ_key
         self.__client = client
+        self.model_store_root = model_store_root if not None else ""
 
     @property
     def client(self) -> "azure.storage.blobage.BlobClient":

--- a/modelstore/storage/azure.py
+++ b/modelstore/storage/azure.py
@@ -60,7 +60,7 @@ class AzureBlobStorage(BlobStorage):
         )
         self.connection_string_key = environ_key
         self.__client = client
-        self.model_store_root = ""
+        self.root_dir = ""
 
     @property
     def client(self) -> "azure.storage.blobage.BlobClient":

--- a/modelstore/storage/blob_storage.py
+++ b/modelstore/storage/blob_storage.py
@@ -87,7 +87,7 @@ class BlobStorage(CloudStorage):
             model_id (str): A UUID4 string that identifies this specific
             model.
         """
-        versions_path = get_versions_path(domain, state_name)
+        versions_path = get_versions_path(self.model_store_root, domain, state_name)
         return os.path.join(versions_path, f"{model_id}.json")
 
     def _upload_extra(self, local_path: str, remote_path: str):
@@ -109,7 +109,7 @@ class BlobStorage(CloudStorage):
         extras: Optional[Union[str, list]] = None,
     ) -> dict:
         # Upload the archive into storage
-        archive_remote_path = get_archive_path(domain, local_path)
+        archive_remote_path = get_archive_path(self.model_store_root, domain, local_path)
         prefix = self._push(local_path, archive_remote_path)
         if extras:
             # If any extras have been defined, they are uploaded
@@ -130,7 +130,7 @@ class BlobStorage(CloudStorage):
             with open(local_path, "w") as out:
                 out.write(json.dumps(meta_data))
             self._push(local_path, self._get_metadata_path(domain, model_id))
-            self._push(local_path, get_domain_path(domain))
+            self._push(local_path, get_domain_path(self.model_store_root, domain))
 
     def get_meta_data(self, domain: str, model_id: str) -> dict:
         """ Returns a model's meta data """
@@ -148,7 +148,7 @@ class BlobStorage(CloudStorage):
         domain"""
         model_meta = None
         if model_id is None:
-            model_domain = get_domain_path(domain)
+            model_domain = get_domain_path(self.model_store_root, domain)
             model_meta = self._read_json_object(model_domain)
             logger.info("Latest model is: %s", model_meta["model"]["model_id"])
         else:
@@ -160,7 +160,7 @@ class BlobStorage(CloudStorage):
 
     def list_domains(self) -> list:
         """ Returns a list of all the existing model domains """
-        domains = get_domains_path()
+        domains = get_domains_path(self.model_store_root)
         domains = self._read_json_objects(domains)
         return [d["model"]["domain"] for d in domains]
 
@@ -169,7 +169,7 @@ class BlobStorage(CloudStorage):
     ) -> list:
         if state_name and not self.state_exists(state_name):
             raise Exception(f"State: '{state_name}' does not exist")
-        versions_path = get_versions_path(domain, state_name)
+        versions_path = get_versions_path(self.model_store_root, domain, state_name)
         versions = self._read_json_objects(versions_path)
         # @TODO sort models by creation time stamp
         return [v["model"]["model_id"] for v in versions]

--- a/modelstore/storage/blob_storage.py
+++ b/modelstore/storage/blob_storage.py
@@ -87,7 +87,7 @@ class BlobStorage(CloudStorage):
             model_id (str): A UUID4 string that identifies this specific
             model.
         """
-        versions_path = get_versions_path(self.model_store_root, domain, state_name)
+        versions_path = get_versions_path(self.root_dir, domain, state_name)
         return os.path.join(versions_path, f"{model_id}.json")
 
     def _upload_extra(self, local_path: str, remote_path: str):
@@ -109,7 +109,7 @@ class BlobStorage(CloudStorage):
         extras: Optional[Union[str, list]] = None,
     ) -> dict:
         # Upload the archive into storage
-        archive_remote_path = get_archive_path(self.model_store_root, domain, local_path)
+        archive_remote_path = get_archive_path(self.root_dir, domain, local_path)
         prefix = self._push(local_path, archive_remote_path)
         if extras:
             # If any extras have been defined, they are uploaded
@@ -130,7 +130,7 @@ class BlobStorage(CloudStorage):
             with open(local_path, "w") as out:
                 out.write(json.dumps(meta_data))
             self._push(local_path, self._get_metadata_path(domain, model_id))
-            self._push(local_path, get_domain_path(self.model_store_root, domain))
+            self._push(local_path, get_domain_path(self.root_dir, domain))
 
     def get_meta_data(self, domain: str, model_id: str) -> dict:
         """ Returns a model's meta data """
@@ -148,7 +148,7 @@ class BlobStorage(CloudStorage):
         domain"""
         model_meta = None
         if model_id is None:
-            model_domain = get_domain_path(self.model_store_root, domain)
+            model_domain = get_domain_path(self.root_dir, domain)
             model_meta = self._read_json_object(model_domain)
             logger.info("Latest model is: %s", model_meta["model"]["model_id"])
         else:
@@ -160,7 +160,7 @@ class BlobStorage(CloudStorage):
 
     def list_domains(self) -> list:
         """ Returns a list of all the existing model domains """
-        domains = get_domains_path(self.model_store_root)
+        domains = get_domains_path(self.root_dir)
         domains = self._read_json_objects(domains)
         return [d["model"]["domain"] for d in domains]
 
@@ -169,7 +169,7 @@ class BlobStorage(CloudStorage):
     ) -> list:
         if state_name and not self.state_exists(state_name):
             raise Exception(f"State: '{state_name}' does not exist")
-        versions_path = get_versions_path(self.model_store_root, domain, state_name)
+        versions_path = get_versions_path(self.root_dir, domain, state_name)
         versions = self._read_json_objects(versions_path)
         # @TODO sort models by creation time stamp
         return [v["model"]["model_id"] for v in versions]

--- a/modelstore/storage/gcloud.py
+++ b/modelstore/storage/gcloud.py
@@ -62,6 +62,7 @@ class GoogleCloudStorage(BlobStorage):
             bucket_name, "MODEL_STORE_GCP_BUCKET"
         )
         self.__client = client
+        self.model_store_root = ""
 
     @property
     def client(self) -> "storage.Client":

--- a/modelstore/storage/gcloud.py
+++ b/modelstore/storage/gcloud.py
@@ -62,7 +62,7 @@ class GoogleCloudStorage(BlobStorage):
             bucket_name, "MODEL_STORE_GCP_BUCKET"
         )
         self.__client = client
-        self.model_store_root = ""
+        self.root_dir = ""
 
     @property
     def client(self) -> "storage.Client":

--- a/modelstore/storage/hosted.py
+++ b/modelstore/storage/hosted.py
@@ -47,7 +47,7 @@ class HostedStorage(CloudStorage):
         self.secret_access_key = _get_environ(
             secret_access_key, "MODELSTORE_ACCESS_KEY"
         )
-        self.model_store_root = ""
+        self.root_dir = ""
 
     def validate(self) -> bool:
         """ Requires an ACCESS_KEY_ID and SECRET_ACCESS_KEY """

--- a/modelstore/storage/hosted.py
+++ b/modelstore/storage/hosted.py
@@ -47,6 +47,7 @@ class HostedStorage(CloudStorage):
         self.secret_access_key = _get_environ(
             secret_access_key, "MODELSTORE_ACCESS_KEY"
         )
+        self.model_store_root = ""
 
     def validate(self) -> bool:
         """ Requires an ACCESS_KEY_ID and SECRET_ACCESS_KEY """

--- a/modelstore/storage/local.py
+++ b/modelstore/storage/local.py
@@ -59,21 +59,22 @@ class FileSystemStorage(BlobStorage):
         """This validates that the directory exists
         and can be written to"""
         # pylint: disable=broad-except
-        try:
-            parent_dir = os.path.split(self.root_dir)[0]
-            # Check that directory exists
-            if not os.path.exists(parent_dir):
-                logger.error("Error: %s does not exist", parent_dir)
-                return False
+        parent_dir = os.path.split(self.root_dir)[0]
 
+        if not os.path.exists(parent_dir):
+            raise Exception("Error: Parent directory to root dir '%s' does not exist", parent_dir)
+            
+        try:
             # Check we can write to it
             source = os.path.join(self.root_dir, ".operator-ai")
             Path(source).touch()
             os.remove(source)
-            return True
         except Exception as ex:
-            logger.error("Error=%s...", str(ex))
-            return False
+            logger.error(ex)
+
+
+        return True
+
 
     def _get_metadata_path(
         self, domain: str, model_id: str, state_name: Optional[str] = None

--- a/modelstore/storage/local.py
+++ b/modelstore/storage/local.py
@@ -52,8 +52,7 @@ class FileSystemStorage(BlobStorage):
                 + " that this library usually appends. Is this intended?"
             )
         root_path = os.path.abspath(root_dir)
-        self.root_dir = root_dir
-        self.root_dir = root_dir
+        self.root_dir = root_path
         logger.debug("Root is: %s", self.root_dir)
 
     def validate(self) -> bool:

--- a/modelstore/storage/local.py
+++ b/modelstore/storage/local.py
@@ -43,16 +43,17 @@ class FileSystemStorage(BlobStorage):
         "optional": [],
     }
 
-    def __init__(self, root_path: Optional[str] = None):
+    def __init__(self, model_store_root: Optional[str] = None):
         super().__init__([])
-        root_path = environment.get_value(root_path, "MODEL_STORE_ROOT")
-        if MODELSTORE_ROOT_PREFIX in root_path:
+
+        if MODELSTORE_ROOT_PREFIX in model_store_root:
             warnings.warn(
                 f'Warning: "{MODELSTORE_ROOT_PREFIX}" is in the root path, and is a value'
                 + " that this library usually appends. Is this intended?"
             )
-        root_path = os.path.abspath(root_path)
-        self.root_dir = root_path
+        root_path = os.path.abspath(model_store_root)
+        self.root_dir = model_store_root
+        self.model_store_root = model_store_root
         logger.debug("Root is: %s", self.root_dir)
 
     def validate(self) -> bool:

--- a/modelstore/storage/local.py
+++ b/modelstore/storage/local.py
@@ -21,7 +21,7 @@ from typing import Optional
 from modelstore.storage.blob_storage import BlobStorage
 from modelstore.storage.util import environment
 from modelstore.storage.util.paths import (
-    MODELSTORE_ROOT,
+    MODELSTORE_ROOT_PREFIX,
     get_model_state_path,
     is_valid_state_name,
 )
@@ -46,9 +46,9 @@ class FileSystemStorage(BlobStorage):
     def __init__(self, root_path: Optional[str] = None):
         super().__init__([])
         root_path = environment.get_value(root_path, "MODEL_STORE_ROOT")
-        if MODELSTORE_ROOT in root_path:
+        if MODELSTORE_ROOT_PREFIX in root_path:
             warnings.warn(
-                f'Warning: "{MODELSTORE_ROOT}" is in the root path, and is a value'
+                f'Warning: "{MODELSTORE_ROOT_PREFIX}" is in the root path, and is a value'
                 + " that this library usually appends. Is this intended?"
             )
         root_path = os.path.abspath(root_path)

--- a/modelstore/storage/local.py
+++ b/modelstore/storage/local.py
@@ -43,17 +43,17 @@ class FileSystemStorage(BlobStorage):
         "optional": [],
     }
 
-    def __init__(self, model_store_root: Optional[str] = None):
+    def __init__(self, root_dir: Optional[str] = None):
         super().__init__([])
 
-        if MODELSTORE_ROOT_PREFIX in model_store_root:
+        if MODELSTORE_ROOT_PREFIX in root_dir:
             warnings.warn(
                 f'Warning: "{MODELSTORE_ROOT_PREFIX}" is in the root path, and is a value'
                 + " that this library usually appends. Is this intended?"
             )
-        root_path = os.path.abspath(model_store_root)
-        self.root_dir = model_store_root
-        self.model_store_root = model_store_root
+        root_path = os.path.abspath(root_dir)
+        self.root_dir = root_dir
+        self.root_dir = root_dir
         logger.debug("Root is: %s", self.root_dir)
 
     def validate(self) -> bool:

--- a/modelstore/storage/util/paths.py
+++ b/modelstore/storage/util/paths.py
@@ -22,7 +22,7 @@ MODELSTORE_ROOT_PREFIX = "operatorai-model-store"
 # @TODO move into blob_storage / override in local
 
 
-def get_archive_path(model_store_root: str, domain: str, local_path: str) -> str:
+def get_archive_path(root_dir: str, domain: str, local_path: str) -> str:
     """Creates a bucket prefix where a model archive will be stored.
     I.e.: :code:`operatorai-model-store/<domain>/<prefix>/<file-name>`
 
@@ -37,10 +37,10 @@ def get_archive_path(model_store_root: str, domain: str, local_path: str) -> str
     # Future: enable different types of prefixes
     # Warning! Mac OS translates ":" in paths to "/"
     prefix = datetime.now().strftime("%Y/%m/%d/%H:%M:%S")
-    return os.path.join(model_store_root, MODELSTORE_ROOT_PREFIX, domain, prefix, file_name)
+    return os.path.join(root_dir, MODELSTORE_ROOT_PREFIX, domain, prefix, file_name)
 
 
-def get_versions_path(model_store_root: str, domain: str, state_name: Optional[str] = None) -> str:
+def get_versions_path(root_dir: str, domain: str, state_name: Optional[str] = None) -> str:
     """Creates a path where a meta-data file about a model is stored.
     I.e.: :code:`operatorai-model-store/<domain>/versions/`
 
@@ -50,18 +50,18 @@ def get_versions_path(model_store_root: str, domain: str, state_name: Optional[s
         state_name (str): A model's state tag (e.g. "prod" or "archived")
     """
     if state_name is not None:
-        return os.path.join(model_store_root, MODELSTORE_ROOT_PREFIX, domain, "versions", state_name)
-    return os.path.join(model_store_root, MODELSTORE_ROOT_PREFIX, domain, "versions")
+        return os.path.join(root_dir, MODELSTORE_ROOT_PREFIX, domain, "versions", state_name)
+    return os.path.join(root_dir, MODELSTORE_ROOT_PREFIX, domain, "versions")
 
 
-def get_domains_path(model_store_root: str,) -> str:
+def get_domains_path(root_dir: str,) -> str:
     """Creates a path where meta-data about the latest trained model
     is stored, i.e.: :code:`operatorai-model-store/domains/`
     """
-    return os.path.join(model_store_root, MODELSTORE_ROOT_PREFIX, "domains")
+    return os.path.join(root_dir, MODELSTORE_ROOT_PREFIX, "domains")
 
 
-def get_domain_path(model_store_root: str, domain: str) -> str:
+def get_domain_path(root_dir: str, domain: str) -> str:
     """Creates a path where meta-data about the latest trained model
     is stored, i.e.: :code:`operatorai-model-store/domains/<domain>.json`
 
@@ -69,7 +69,7 @@ def get_domain_path(model_store_root: str, domain: str) -> str:
         domain (str): A group of models that are trained for the
         same end-use are given the same domain.
     """
-    domains_path = get_domains_path(model_store_root)
+    domains_path = get_domains_path(root_dir)
     return os.path.join(domains_path, f"{domain}.json")
 
 

--- a/modelstore/storage/util/paths.py
+++ b/modelstore/storage/util/paths.py
@@ -17,12 +17,12 @@ from typing import Optional
 
 from modelstore.utils.log import logger
 
-MODELSTORE_ROOT = "operatorai-model-store"
+MODELSTORE_ROOT_PREFIX = "operatorai-model-store"
 
 # @TODO move into blob_storage / override in local
 
 
-def get_archive_path(domain: str, local_path: str) -> str:
+def get_archive_path(model_store_root: str, domain: str, local_path: str) -> str:
     """Creates a bucket prefix where a model archive will be stored.
     I.e.: :code:`operatorai-model-store/<domain>/<prefix>/<file-name>`
 
@@ -37,10 +37,10 @@ def get_archive_path(domain: str, local_path: str) -> str:
     # Future: enable different types of prefixes
     # Warning! Mac OS translates ":" in paths to "/"
     prefix = datetime.now().strftime("%Y/%m/%d/%H:%M:%S")
-    return os.path.join(MODELSTORE_ROOT, domain, prefix, file_name)
+    return os.path.join(model_store_root, MODELSTORE_ROOT_PREFIX, domain, prefix, file_name)
 
 
-def get_versions_path(domain: str, state_name: Optional[str] = None) -> str:
+def get_versions_path(model_store_root: str, domain: str, state_name: Optional[str] = None) -> str:
     """Creates a path where a meta-data file about a model is stored.
     I.e.: :code:`operatorai-model-store/<domain>/versions/`
 
@@ -50,18 +50,18 @@ def get_versions_path(domain: str, state_name: Optional[str] = None) -> str:
         state_name (str): A model's state tag (e.g. "prod" or "archived")
     """
     if state_name is not None:
-        return os.path.join(MODELSTORE_ROOT, domain, "versions", state_name)
-    return os.path.join(MODELSTORE_ROOT, domain, "versions")
+        return os.path.join(model_store_root, MODELSTORE_ROOT_PREFIX, domain, "versions", state_name)
+    return os.path.join(model_store_root, MODELSTORE_ROOT_PREFIX, domain, "versions")
 
 
-def get_domains_path() -> str:
+def get_domains_path(model_store_root: str,) -> str:
     """Creates a path where meta-data about the latest trained model
     is stored, i.e.: :code:`operatorai-model-store/domains/`
     """
-    return os.path.join(MODELSTORE_ROOT, "domains")
+    return os.path.join(model_store_root, MODELSTORE_ROOT_PREFIX, "domains")
 
 
-def get_domain_path(domain: str) -> str:
+def get_domain_path(model_store_root: str, domain: str) -> str:
     """Creates a path where meta-data about the latest trained model
     is stored, i.e.: :code:`operatorai-model-store/domains/<domain>.json`
 
@@ -69,7 +69,7 @@ def get_domain_path(domain: str) -> str:
         domain (str): A group of models that are trained for the
         same end-use are given the same domain.
     """
-    domains_path = get_domains_path()
+    domains_path = get_domains_path(model_store_root)
     return os.path.join(domains_path, f"{domain}.json")
 
 
@@ -81,7 +81,7 @@ def get_model_states_path() -> str:
         domain (str): A group of models that are trained for the
         same end-use are given the same domain.
     """
-    return os.path.join(MODELSTORE_ROOT, "model_states")
+    return os.path.join(MODELSTORE_ROOT_PREFIX, "model_states")
 
 
 def get_model_state_path(state_name: str) -> str:

--- a/tests/models/test_model_manager.py
+++ b/tests/models/test_model_manager.py
@@ -27,7 +27,7 @@ from modelstore.storage.local import FileSystemStorage
 
 class MockCloudStorage(FileSystemStorage):
     def __init__(self, tmpdir):
-        super().__init__(root_path=str(tmpdir))
+        super().__init__(root_dir=str(tmpdir))
         self.called = False
 
     def upload(

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -20,7 +20,7 @@ import modelstore
 import pytest
 from modelstore.storage.local import FileSystemStorage
 from modelstore.storage.util.paths import (
-    MODELSTORE_ROOT,
+    MODELSTORE_ROOT_PREFIX,
     get_archive_path,
     get_domain_path,
     get_model_state_path,
@@ -66,7 +66,7 @@ def test_state_exists(mock_blob_storage):
 def test_get_metadata_path(mock_blob_storage):
     exp = os.path.join(
         mock_blob_storage.root_dir,
-        MODELSTORE_ROOT,
+        MODELSTORE_ROOT_PREFIX,
         "domain",
         "versions",
         "model-id.json",
@@ -86,7 +86,7 @@ def test_set_meta_data(mock_blob_storage):
     # Expected two uploads
     # (1) The meta data for the 'latest' model
     meta_data = os.path.join(
-        mock_blob_storage.root_dir, get_domain_path("test-domain")
+        mock_blob_storage.root_dir, get_domain_path("", "test-domain")
     )
     assert get_file_contents(meta_data) == meta_str
 

--- a/tests/storage/test_local.py
+++ b/tests/storage/test_local.py
@@ -33,7 +33,7 @@ from tests.storage.test_utils import (
 
 @pytest.fixture
 def file_system_storage(tmp_path):
-    return FileSystemStorage(root_path=str(tmp_path))
+    return FileSystemStorage(root_dir=str(tmp_path))
 
 
 def test_create_from_environment_variables(monkeypatch):

--- a/tests/storage/util/test_paths.py
+++ b/tests/storage/util/test_paths.py
@@ -22,45 +22,45 @@ from modelstore.storage.util import paths
 
 def test_get_archive_path():
     prefix = datetime.now().strftime("%Y/%m/%d/%H:%M:%S")
-    exp = os.path.join(paths.MODELSTORE_ROOT, "domain", prefix, "file-name")
+    exp = os.path.join(paths.MODELSTORE_ROOT_PREFIX, "domain", prefix, "file-name")
     res = paths.get_archive_path("domain", "path/to/file-name")
     assert exp == res
 
 
 def test_get_versions_path():
-    exp = os.path.join(paths.MODELSTORE_ROOT, "example-domain", "versions")
-    res = paths.get_versions_path("example-domain")
+    exp = os.path.join(paths.MODELSTORE_ROOT_PREFIX, "example-domain", "versions")
+    res = paths.get_versions_path("", "example-domain")
     assert exp == res
 
 
 def test_get_versions_path_with_state():
     exp = os.path.join(
-        paths.MODELSTORE_ROOT, "example-domain", "versions", "prod"
+        paths.MODELSTORE_ROOT_PREFIX, "example-domain", "versions", "prod"
     )
-    res = paths.get_versions_path("example-domain", "prod")
+    res = paths.get_versions_path("", "example-domain", "prod")
     assert exp == res
 
 
 def test_get_domains_path():
-    exp = os.path.join(paths.MODELSTORE_ROOT, "domains")
+    exp = os.path.join(paths.MODELSTORE_ROOT_PREFIX, "domains")
     res = paths.get_domains_path()
     assert exp == res
 
 
 def test_get_domain_path():
-    exp = os.path.join(paths.MODELSTORE_ROOT, "domains", "domain.json")
-    res = paths.get_domain_path("domain")
+    exp = os.path.join(paths.MODELSTORE_ROOT_PREFIX, "domains", "domain.json")
+    res = paths.get_domain_path("", "domain")
     assert exp == res
 
 
 def test_get_model_states_path():
-    exp = os.path.join(paths.MODELSTORE_ROOT, "model_states")
+    exp = os.path.join(paths.MODELSTORE_ROOT_PREFIX, "model_states")
     res = paths.get_model_states_path()
     assert exp == res
 
 
 def test_get_model_state_path():
-    exp = os.path.join(paths.MODELSTORE_ROOT, "model_states", "prod.json")
+    exp = os.path.join(paths.MODELSTORE_ROOT_PREFIX, "model_states", "prod.json")
     res = paths.get_model_state_path("prod")
     assert exp == res
 


### PR DESCRIPTION
This PR adds the ability to set the root dir in the was bucket where the model store is created. It will provide users more flexibility so that they do not have to create a new AWS bucket for every model store, and instead can choose where the directory is placed. 