### PR TITLE
Remove dependency on onnxruntime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 dataclasses==0.8; python_version < '3.7'
 gitpython>=3.1.11
 joblib>=1.0.0
-onnxruntime>=1.3.0
 requests>=2.23.0
 tqdm>=4.54.1
 click>=7.0


### PR DESCRIPTION
The onnxruntime is not currently available on M1 macs. This is not a strong dependency for `modelstore`, and it was duplicated across `requirements.txt` and `requirements-dev.txt`, so this PR removes it from the former.

- https://github.com/microsoft/onnxruntime/issues/6633
- https://github.com/onnx/onnx/issues/3129