### PR TITLE
Fix regression with Keras models

### DIFF
--- a/modelstore/models/managers.py
+++ b/modelstore/models/managers.py
@@ -83,7 +83,13 @@ def matching_managers(managers: list, **kwargs) -> List[ModelManager]:
 
 
 def get_manager(name: str, storage: CloudStorage = None) -> ModelManager:
-    manager = _LIBRARIES[name](storage)
+    if name == "keras":
+        # Older versions of modelstore (before 0.0.73) had separate
+        # managers for Keras and Tensorflow. Setting this explicitly
+        # here ensures that modelstore remains backward compatible
+        manager = TensorflowManager(storage)
+    else:
+        manager = _LIBRARIES[name](storage)
     if all(module_exists(x) for x in manager.required_dependencies()):
         return manager
     raise ValueError(


### PR DESCRIPTION
The `KerasManager` was merged with the `TensorflowManager` in `modelstore==0.0.73`, but this makes `modelstore` have a problem where it is not backwards compatible anymore. This PR fixes that and adds some tests for this specific case.

- https://github.com/operatorai/modelstore/issues/144