### PR TITLE
Remove python-info.json file from model archive

### DIFF
--- a/modelstore/metadata/code/dependencies.py
+++ b/modelstore/metadata/code/dependencies.py
@@ -15,11 +15,9 @@ import importlib
 import sys
 
 import pkg_resources
-from modelstore.models.common import save_json
 from modelstore.utils.log import logger
 
 # pylint: disable=broad-except
-_PYTHON_INFO_FILE = "python-info.json"
 
 
 def _get_version(modname: str) -> str:
@@ -63,11 +61,3 @@ def get_dependency_versions(modnames: list) -> dict:
 def module_exists(modname: str) -> bool:
     """ Returns True if a module has been installed """
     return _get_version(modname) is not None
-
-
-def save_dependencies(tmp_dir: str, deps: list) -> str:
-    """ Saves all of the current dependencies to file """
-    # @TODO move
-    deps_info = get_dependency_versions(deps) 
-    deps_info = {k: v for k, v in deps_info.items() if v is not None}
-    return save_json(tmp_dir, _PYTHON_INFO_FILE, deps_info)

--- a/modelstore/models/model_manager.py
+++ b/modelstore/models/model_manager.py
@@ -20,7 +20,6 @@ from abc import ABC, ABCMeta, abstractmethod
 
 import numpy as np
 from modelstore.metadata import metadata
-from modelstore.metadata.code.dependencies import save_dependencies
 from modelstore.storage.storage import CloudStorage
 
 
@@ -122,7 +121,6 @@ class ModelManager(ABC):
         part of the artifacts archive.
         """
         file_paths = [
-            save_dependencies(tmp_dir, self.get_dependencies()),
             self.model_info(**kwargs).dumps(tmp_dir),
         ]
         for func in self._get_functions(**kwargs):

--- a/tests/metadata/code/test_dependencies.py
+++ b/tests/metadata/code/test_dependencies.py
@@ -11,8 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-import json
-import os
 import sys
 
 import pytest
@@ -59,27 +57,3 @@ def test_get_dependency_versions():
 def test_module_exists():
     assert dependencies.module_exists("pytest") is True
     assert dependencies.module_exists("a-missing-mod") is False
-
-
-def test_save_dependencies(tmp_path):
-    test_deps = [
-        "pytest",
-        "pylint",
-        "black",
-        "flake8",
-        "isort",
-        "a-missing-dependency",
-    ]
-    expected = {
-        "black": "22.3.0",
-        "flake8": "4.0.1",
-        "isort": "5.10.1",
-        "pytest": pytest.__version__,
-        "pylint": "2.13.5",
-    }
-    tmp_file = dependencies.save_dependencies(tmp_path, test_deps)
-    assert os.path.split(tmp_file)[1] == "python-info.json"
-    # pylint: disable=unspecified-encoding
-    with open(tmp_file, "r") as lines:
-        result = json.loads(lines.read())
-    assert result == expected

--- a/tests/models/test_model_manager.py
+++ b/tests/models/test_model_manager.py
@@ -108,7 +108,6 @@ def test_collect_files(mock_manager):
     exp = sorted(
         [
             os.path.join(tmp_path, "model-info.json"),
-            os.path.join(tmp_path, "python-info.json"),
             os.path.join(tmp_path, "model.joblib"),
             os.path.join(tmp_path, "config.json"),
         ]
@@ -171,7 +170,6 @@ def test_create_archive(mock_manager, mock_file):
     exp = sorted(
         [
             "model-info.json",
-            "python-info.json",
             "model.joblib",
             "config.json",
             os.path.join("extras", "extra-file.csv"),


### PR DESCRIPTION
This file is unused and the information it holds is captured in the model's meta data