### PR TITLE
Issue 197 (archives being overwritten if generated too quickly)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Unreleased
+
+**🐛  Bug fixes & general updates**
+
+Fixes an issue where model archives would be overwritten if models are uploaded too quickly ([#208](https://github.com/operatorai/modelstore/pull/208), thanks [@shsnyder](https://github.com/operatorai/modelstore/issues/197)).
+
 ## modelstore 0.0.76 ([October 2022](https://github.com/operatorai/modelstore/pull/205))
 
 **🐛  Bug fixes & general updates**

--- a/modelstore/models/model_manager.py
+++ b/modelstore/models/model_manager.py
@@ -210,7 +210,7 @@ class ModelManager(ABC):
         archive_path = self._create_archive(**kwargs)
 
         # Upload the model archive and any additional extras
-        storage_meta_data = self.storage.upload(domain, archive_path)
+        storage_meta_data = self.storage.upload(domain, model_id, archive_path)
         meta_data = metadata.Summary.generate(
             code_meta_data=metadata.Code.generate(
                 deps_list=self.get_dependencies()

--- a/modelstore/storage/blob_storage.py
+++ b/modelstore/storage/blob_storage.py
@@ -121,9 +121,14 @@ class BlobStorage(CloudStorage):
             f"{model_id}.json",
         )
 
-    def upload(self, domain: str, local_path: str) -> metadata.Storage:
+    def upload(self, domain: str, model_id: str, local_path: str) -> metadata.Storage:
         # Upload the archive into storage
-        archive_remote_path = get_archive_path(self.root_prefix, domain, local_path)
+        archive_remote_path = get_archive_path(
+            self.root_prefix,
+            domain,
+            model_id,
+            local_path
+        )
         prefix = self._push(local_path, archive_remote_path)
         return self._storage_location(prefix)
 

--- a/modelstore/storage/storage.py
+++ b/modelstore/storage/storage.py
@@ -40,9 +40,7 @@ class CloudStorage(ABC):
 
     @abstractmethod
     def upload(
-        self,
-        domain: str,
-        local_path: str,
+        self, domain: str, model_id: str, local_path: str
     ) -> metadata.Storage:
         """Uploads an archive to this type of storage
         :param extras can be a path to a file or list of files

--- a/modelstore/storage/util/paths.py
+++ b/modelstore/storage/util/paths.py
@@ -22,7 +22,7 @@ MODELSTORE_ROOT_PREFIX = "operatorai-model-store"
 
 def get_archive_path(root_dir: str, domain: str, model_id: str, local_path: str) -> str:
     """Creates a bucket prefix where a model archive will be stored.
-    I.e.: :code:`operatorai-model-store/<domain>/<prefix>/<file-name>`
+    I.e.: :code:`operatorai-model-store/<domain>/<prefix>/<model-id>/<file-name>`
 
     Args:
         root_dir (str): The root directory/prefix for this type

--- a/modelstore/storage/util/paths.py
+++ b/modelstore/storage/util/paths.py
@@ -20,13 +20,18 @@ MODELSTORE_ROOT_PREFIX = "operatorai-model-store"
 # @TODO move into blob_storage / override in local
 
 
-def get_archive_path(root_dir: str, domain: str, local_path: str) -> str:
+def get_archive_path(root_dir: str, domain: str, model_id: str, local_path: str) -> str:
     """Creates a bucket prefix where a model archive will be stored.
     I.e.: :code:`operatorai-model-store/<domain>/<prefix>/<file-name>`
 
     Args:
+        root_dir (str): The root directory/prefix for this type
+        of storage
+
         domain (str): A group of models that are trained for the
         same end-use are given the same domain.
+
+        model_id (str): The specific identifier for this model
 
         local_path (str): The path to the local file that is
         to be updated.
@@ -35,7 +40,14 @@ def get_archive_path(root_dir: str, domain: str, local_path: str) -> str:
     # Future: enable different types of prefixes
     # Warning! Mac OS translates ":" in paths to "/"
     prefix = datetime.now().strftime("%Y.%m.%d-%H.%M.%S")
-    return os.path.join(root_dir, MODELSTORE_ROOT_PREFIX, domain, prefix, file_name)
+    return os.path.join(
+        root_dir,
+        MODELSTORE_ROOT_PREFIX,
+        domain,
+        prefix,
+        model_id,
+        file_name
+    )
 
 
 def get_models_path(

--- a/tests/storage/test_blob_storage_artifacts.py
+++ b/tests/storage/test_blob_storage_artifacts.py
@@ -39,10 +39,11 @@ def test_upload(mock_blob_storage, mock_model_file):
         get_archive_path(
             mock_blob_storage.root_prefix,
             "test-domain",
+            "model-id",
             mock_model_file,
         ),
     )
-    meta_data = mock_blob_storage.upload("test-domain", mock_model_file)
+    meta_data = mock_blob_storage.upload("test-domain", "model-id", mock_model_file)
     assert meta_data.type == "file_system"
     assert meta_data.path == model_path
     assert os.path.exists(model_path)
@@ -63,7 +64,7 @@ def test_delete_model(mock_blob_storage, mock_model_file):
     domain = "test-domain"
     model_id = "test-model-id"
     model_state = "test-state"
-    storage_meta = mock_blob_storage.upload(domain, mock_model_file)
+    storage_meta = mock_blob_storage.upload(domain, model_id, mock_model_file)
     meta_data = metadata.Summary.generate(
         code_meta_data=None,
         model_meta_data=metadata.Model.generate(
@@ -86,6 +87,7 @@ def test_delete_model(mock_blob_storage, mock_model_file):
         get_archive_path(
             mock_blob_storage.root_prefix,
             domain,
+            model_id,
             mock_model_file,
         ),
     )

--- a/tests/storage/util/test_paths.py
+++ b/tests/storage/util/test_paths.py
@@ -26,9 +26,14 @@ def test_get_archive_path(tmp_path, has_root_prefix):
     root = str(tmp_path) if has_root_prefix else ""
     prefix = datetime.now().strftime("%Y.%m.%d-%H.%M.%S")
     exp = os.path.join(
-        root, paths.MODELSTORE_ROOT_PREFIX, "domain", prefix, "file-name"
+        root,
+        paths.MODELSTORE_ROOT_PREFIX,
+        "domain",
+        prefix,
+        "model-id",
+        "file-name"
     )
-    res = paths.get_archive_path(root, "domain", "path/to/file-name")
+    res = paths.get_archive_path(root, "domain", "model-id", "path/to/file-name")
     assert exp == res
 
 


### PR DESCRIPTION
**Problem**

- https://github.com/operatorai/modelstore/issues/197

> the versions directory gets updated correctly BUT the timestamped archives get overridden.

**Diagnosis**

The versions directory was getting updated correctly because version paths are unique - they have the model's ID:

```
`operatorai-model-store/<domain>/versions/<model-id>.json`
```

But the archive path was not unique at the second-level:

```
operatorai-model-store/<domain>/%Y.%m.%d-%H.%M.%S/<file-name>
```

**Resolution**

To fix this, I've updated archive paths to be unique:

```
operatorai-model-store/<domain>/%Y.%m.%d-%H.%M.%S/<model-id>/<file-name>
```

If two models get uploaded in the same second, they will both sit in the same timestamped prefix, but will not overwrite each other's archives.

This should not impact any models that are currently stored, since their full storage path is stored in the model's meta-data/version file.