### PR TITLE
Make filesystem modelstore independent of creator's root path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**🆕  New functionality**
+
+You can move model stores that you created in one file system directory to another one (e.g., making it a mounted volume in a container) and `modelstore` will continue to work ([#209](https://github.com/operatorai/modelstore/pull/209), thanks [@hauks96](https://github.com/operatorai/modelstore/issues/189)).
+
 **🐛  Bug fixes & general updates**
 
 Fixes an issue where model archives would be overwritten if models are uploaded too quickly ([#208](https://github.com/operatorai/modelstore/pull/208), thanks [@shsnyder](https://github.com/operatorai/modelstore/issues/197)).

--- a/modelstore/metadata/storage/storage.py
+++ b/modelstore/metadata/storage/storage.py
@@ -30,8 +30,9 @@ class Storage:
     type: str
 
     # Path-like storage (e.g. local)
+    root: Optional[str] = field(default=None, metadata=config(exclude=exclude_field))
     path: Optional[str] = field(default=None, metadata=config(exclude=exclude_field))
-    
+
     # Container-like storage
     bucket: Optional[str] = field(default=None, metadata=config(exclude=exclude_field))
     prefix: Optional[str] = field(default=None, metadata=config(exclude=exclude_field))
@@ -40,15 +41,13 @@ class Storage:
     container: Optional[str] = field(default=None, metadata=config(exclude=exclude_field))
 
     @classmethod
-    def from_path(cls, storage_type: str, path: str) -> "Storage":
+    def from_path(cls, storage_type: str, root: str, path: str) -> "Storage":
         """ Generates the meta data about where the model
         is going to be saved when it is saved in path-like storage """
         return Storage(
             type=storage_type,
+            root=root,
             path=path,
-            bucket=None,
-            container=None,
-            prefix=None,
         )
 
     @classmethod
@@ -57,9 +56,7 @@ class Storage:
         is going to be saved when it is saved in container storage """
         return Storage(
             type=storage_type,
-            path=None,
             bucket=bucket,
-            container=None,
             prefix=prefix,
         )
 
@@ -69,8 +66,6 @@ class Storage:
         is going to be saved when it is saved in an Azure container """
         return Storage(
             type=storage_type,
-            path=None,
-            bucket=None,
             container=container,
             prefix=prefix,
         )

--- a/modelstore/model_store.py
+++ b/modelstore/model_store.py
@@ -195,7 +195,6 @@ class ModelStore:
 
     def model_exists(self, domain: str, model_id: str) -> bool:
         """ Returns True if a model with the given id exists in the domain """
-        # @TODO: use head_object instead of full pull
         try:
             self.storage.get_meta_data(domain, model_id)
             return True
@@ -264,25 +263,19 @@ class ModelStore:
         local_path = os.path.abspath(local_path)
         archive_path = self.storage.download(local_path, domain, model_id)
         with tarfile.open(archive_path, "r:gz") as tar:
-            def is_within_directory(directory, target):
-                
+            def is_within_directory(directory, target):            
                 abs_directory = os.path.abspath(directory)
                 abs_target = os.path.abspath(target)
-            
                 prefix = os.path.commonprefix([abs_directory, abs_target])
-                
                 return prefix == abs_directory
-            
+      
             def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-            
                 for member in tar.getmembers():
                     member_path = os.path.join(path, member.name)
                     if not is_within_directory(path, member_path):
                         raise Exception("Attempted Path Traversal in Tar File")
-            
                 tar.extractall(path, members, numeric_owner=numeric_owner) 
-                
-            
+ 
             safe_extract(tar, local_path)
         os.remove(archive_path)
         return local_path

--- a/modelstore/storage/aws.py
+++ b/modelstore/storage/aws.py
@@ -130,6 +130,7 @@ class AWSStorage(BlobStorage):
     def _get_storage_location(self, meta_data: metadata.Storage) -> str:
         """Extracts the storage location from a meta data dictionary"""
         if self.bucket_name != meta_data.bucket:
+            # @TODO: downgrade to a warning if the file exists
             raise ValueError("Meta-data has a different bucket name")
         return meta_data.prefix
 

--- a/modelstore/storage/aws.py
+++ b/modelstore/storage/aws.py
@@ -91,10 +91,7 @@ class AWSStorage(BlobStorage):
     def _push(self, file_path: str, prefix: str) -> str:
         logger.info("Uploading to: %s...", prefix)
         self.client.upload_file(file_path, self.bucket_name, prefix)
-        return os.path.join(
-            prefix,
-            os.path.split(file_path)[1],
-        )
+        return prefix
 
     def _pull(self, prefix: str, dir_path: str) -> str:
         try:

--- a/modelstore/storage/blob_storage.py
+++ b/modelstore/storage/blob_storage.py
@@ -222,10 +222,9 @@ class BlobStorage(CloudStorage):
 
     def create_model_state(self, state_name: str):
         """Creates a state label that can be used to tag models"""
-        if is_reserved_state(state_name):
-            raise ValueError(f"Cannot create state with reserved name: '{state_name}'")
-        if is_valid_state_name(state_name):
-            raise ValueError(f"Cannot create state with invalid name: '{state_name}'")
+        if not is_reserved_state(state_name):
+            if not is_valid_state_name(state_name):
+                raise ValueError(f"Cannot create state with name: '{state_name}'")
         if self.state_exists(state_name):
             logger.debug("Model state '%s' already exists", state_name)
             return  # Exception is not raised; create_model_state() is idempotent

--- a/modelstore/storage/blob_storage.py
+++ b/modelstore/storage/blob_storage.py
@@ -238,7 +238,7 @@ class BlobStorage(CloudStorage):
                     "state_name": state_name,
                 }
                 out.write(json.dumps(state_data))
-            state_path = get_model_state_path(self.root_prefix, state_name)
+            state_path = get_model_states_path(self.root_prefix)
             self._push(state_data_path, state_path)
 
     def set_model_state(self, domain: str, model_id: str, state_name: str):

--- a/modelstore/storage/blob_storage.py
+++ b/modelstore/storage/blob_storage.py
@@ -29,7 +29,8 @@ from modelstore.storage.util.paths import (
     get_domains_path,
     get_model_state_path,
     get_model_states_path,
-    get_models_path,
+    get_model_versions_path,
+    get_model_version_path,
 )
 from modelstore.storage.states.model_states import (
     is_valid_state_name,
@@ -63,7 +64,9 @@ class BlobStorage(CloudStorage):
         super().__init__(required_deps)
         if root_prefix_env_key is not None:
             root_prefix = environment.get_value(
-                root_prefix, root_prefix_env_key, allow_missing=True
+                root_prefix,
+                root_prefix_env_key,
+                allow_missing=True
             )
         self.root_prefix = root_prefix if root_prefix is not None else ""
         logger.debug("Root prefix is: %s", self.root_prefix)
@@ -103,33 +106,15 @@ class BlobStorage(CloudStorage):
         """Extracts the storage location from a meta data dictionary"""
         raise NotImplementedError()
 
-    def _get_metadata_path(
-        self, domain: str, model_id: str, state_name: Optional[str] = None
-    ) -> str:
-        """Creates a path where a meta-data file about a model is stored.
-        I.e.: :code:`operatorai-model-store/<domain>/versions/<model-id>.json`
-
-        Args:
-            domain (str): A group of models that are trained for the
-            same end-use are given the same domain.
-
-            model_id (str): A UUID4 string that identifies this specific
-            model.
-        """
-        return os.path.join(
-            get_models_path(self.root_prefix, domain, state_name),
-            f"{model_id}.json",
-        )
-
     def upload(self, domain: str, model_id: str, local_path: str) -> metadata.Storage:
-        # Upload the archive into storage
-        archive_remote_path = get_archive_path(
+        """ Uploads the archive into storage """
+        archive_path = get_archive_path(
             self.root_prefix,
             domain,
             model_id,
             local_path
         )
-        prefix = self._push(local_path, archive_remote_path)
+        prefix = self._push(local_path, archive_path)
         return self._storage_location(prefix)
 
     def download(self, local_path: str, domain: str, model_id: str = None):
@@ -138,6 +123,7 @@ class BlobStorage(CloudStorage):
         domain"""
         model_meta = None
         if model_id is None:
+            # @TODO switch to using dataclass fields
             model_domain = get_domain_path(self.root_prefix, domain)
             model_meta = self._read_json_object(model_domain)
             model_id = model_meta["model"]["model_id"]
@@ -176,7 +162,11 @@ class BlobStorage(CloudStorage):
         self.set_model_state(domain, model_id, ReservedModelStates.DELETED.value)
 
         logger.debug("Deleting meta-data for %s=%s", domain, model_id)
-        remote_path = self._get_metadata_path(domain, model_id)
+        remote_path = get_model_version_path(
+            self.root_prefix,
+            domain,
+            model_id,
+        )
         self._remove(remote_path)
 
         # @TODO (future): the model that is being deleted may be also set
@@ -185,9 +175,9 @@ class BlobStorage(CloudStorage):
 
     def list_domains(self) -> list:
         """Returns a list of all the existing model domains"""
-        domains = get_domains_path(self.root_prefix)
-        domains = self._read_json_objects(domains)
-        
+        domains_path = get_domains_path(self.root_prefix)
+        domains = self._read_json_objects(domains_path)
+     
         return [d["model"]["domain"] for d in domains]
 
     def get_domain(self, domain: str) -> dict:
@@ -201,23 +191,25 @@ class BlobStorage(CloudStorage):
     def list_models(self, domain: str, state_name: Optional[str] = None) -> list:
         if state_name and not self.state_exists(state_name):
             raise Exception(f"State: '{state_name}' does not exist")
+
+        # Assert the domain exists
         _ = self.get_domain(domain)
-        models_path = get_models_path(self.root_prefix, domain, state_name)
+
+        # List the models in the domain
+        models_path = get_model_versions_path(self.root_prefix, domain, state_name)
         models = self._read_json_objects(models_path)
-        # @TODO sort models by creation time stamp
+
+        # @TODO sort models by creation time stamp; use dataclass fields
         return [v["model"]["model_id"] for v in models]
 
     def state_exists(self, state_name: str) -> bool:
         """Returns whether a model state with name state_name exists"""
         try:
             state_path = get_model_state_path(self.root_prefix, state_name)
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                self._pull(state_path, tmp_dir)
+            _ = self._pull_and_load(state_path)
             return True
-            # pylint: disable=broad-except,invalid-name
-        except Exception as e:
-            # @TODO - check the error type
-            logger.debug("Error checking state: %s", str(e))
+        except FilePullFailedException as exc:
+            logger.debug("Error checking state: %s", str(exc))
             return False
 
     def list_model_states(self) -> list:
@@ -230,9 +222,10 @@ class BlobStorage(CloudStorage):
 
     def create_model_state(self, state_name: str):
         """Creates a state label that can be used to tag models"""
-        if not is_reserved_state(state_name):
-            if not is_valid_state_name(state_name):
-                raise ValueError(f"Cannot create state with name: '{state_name}'")
+        if is_reserved_state(state_name):
+            raise ValueError(f"Cannot create state with reserved name: '{state_name}'")
+        if is_valid_state_name(state_name):
+            raise ValueError(f"Cannot create state with invalid name: '{state_name}'")
         if self.state_exists(state_name):
             logger.debug("Model state '%s' already exists", state_name)
             return  # Exception is not raised; create_model_state() is idempotent
@@ -261,10 +254,21 @@ class BlobStorage(CloudStorage):
             # with typos and other similar mistakes
             logger.debug("Model state '%s' does not exist", state_name)
             raise ValueError(f"State '{state_name}' does not exist")
-        model_path = self._get_metadata_path(domain, model_id)
-        model_state_path = self._get_metadata_path(domain, model_id, state_name)
+        
         with tempfile.TemporaryDirectory() as tmp_dir:
+            model_path = get_model_version_path(
+                self.root_prefix,
+                domain,
+                model_id,
+            )
             local_model_path = self._pull(model_path, tmp_dir)
+
+            model_state_path = get_model_version_path(
+                self.root_prefix,
+                domain,
+                model_id,
+                state_name,
+            )
             self._push(local_model_path, model_state_path)
         logger.debug("Successfully set %s=%s to state=%s", domain, model_id, state_name)
 
@@ -290,47 +294,48 @@ class BlobStorage(CloudStorage):
             # with typos and other similar mistakes
             logger.debug("Model state '%s' does not exist", state_name)
             raise ValueError(f"State '{state_name}' does not exist")
-        model_state_path = self._get_metadata_path(domain, model_id, state_name)
+
+        model_state_path = get_model_version_path(
+            self.root_prefix,
+            domain,
+            model_id,
+            state_name,
+        )
         if self._remove(model_state_path):
             logger.debug(
-                "Successfully unset %s=%s from state=%s", domain, model_id, state_name
+                "Successfully unset %s=%s from state=%s",
+                domain,
+                model_id,
+                state_name
             )
         else:
             logger.debug(
-                "Model  %s=%s was not set to state=%s", domain, model_id, state_name
+                "Model  %s=%s was not set to state=%s",
+                domain,
+                model_id,
+                state_name
             )
-
-    def _get_metadata_path(
-        self, domain: str, model_id: str, state_name: Optional[str] = None
-    ) -> str:
-        """Creates a path where a meta-data file about a model is stored.
-        I.e.: :code:`operatorai-model-store/<domain>/versions/<model-id>.json`
-
-        Args:
-            domain (str): A group of models that are trained for the
-            same end-use are given the same domain.
-
-            model_id (str): A UUID4 string that identifies this specific
-            model.
-        """
-        return os.path.join(
-            get_models_path(self.root_prefix, domain, state_name), f"{model_id}.json"
-        )
 
     def set_meta_data(self, domain: str, model_id: str, meta_data: metadata.Summary):
         logger.debug("Setting meta-data for %s=%s", domain, model_id)
         with tempfile.TemporaryDirectory() as tmp_dir:
             local_path = os.path.join(tmp_dir, f"{model_id}.json")
-            remote_path = self._get_metadata_path(domain, model_id)
-
             meta_data.dumps(local_path)
+
+            remote_path = get_model_version_path(
+                self.root_prefix,
+                domain,
+                model_id,
+            )
             self._push(local_path, remote_path)
 
-            # @TODO this is setting the "latest" model implicitly
+            # @TODO (future) this is setting the "latest" model implicitly
             remote_path = get_domain_path(self.root_prefix, domain)
             self._push(local_path, remote_path)
 
     def _pull_and_load(self, remote_path: str) -> dict:
+        """ Downloads a file from the registry to a temporary directory
+        and tries to load it as a JSON dictionary """
         with tempfile.TemporaryDirectory() as tmp_dir:
             local_path = self._pull(remote_path, tmp_dir)
             # pylint: disable=unspecified-encoding
@@ -338,11 +343,17 @@ class BlobStorage(CloudStorage):
                 return json.loads(lines.read())
 
     def get_meta_data(self, domain: str, model_id: str) -> metadata.Summary:
-        if any(x in [None, ""] for x in [domain, model_id]):
-            raise ValueError("domain and model_id must be set")
-        logger.debug("Retrieving meta-data for %s=%s", domain, model_id)
-        remote_path = self._get_metadata_path(domain, model_id)
+        """ Returns the meta data for a given model """
+        # Assert that the domain exists
+        _ = self.get_domain(domain)
+        
         try:
+            logger.debug("Retrieving meta-data for %s=%s", domain, model_id)
+            remote_path = get_model_version_path(
+                self.root_prefix,
+                domain,
+                model_id,
+            )
             with tempfile.TemporaryDirectory() as tmp_dir:
                 local_path = self._pull(remote_path, tmp_dir)
                 return metadata.Summary.loads(local_path)
@@ -355,8 +366,11 @@ class BlobStorage(CloudStorage):
             # 4. A different error occurred (e.g. connectivity)
             # The block below currently checks for (2) and (3)
             try:
-                remote_path = self._get_metadata_path(
-                    domain, model_id, ReservedModelStates.DELETED.value
+                remote_path = get_model_version_path(
+                    self.root_prefix,
+                    domain,
+                    model_id,
+                    ReservedModelStates.DELETED.value,
                 )
                 self._pull_and_load(remote_path)
                 raise ModelDeletedException(domain, model_id) from exc

--- a/modelstore/storage/gcloud.py
+++ b/modelstore/storage/gcloud.py
@@ -168,28 +168,30 @@ class GoogleCloudStorage(BlobStorage):
                 )
                 return False
 
-    def _push(self, source: str, destination: str) -> str:
+    def _push(self, file_path: str, prefix: str) -> str:
         if self.is_anon_client:
             raise NotImplementedError(
                 "File upload is only supported for authenticated clients."
             )
-        logger.info("Uploading to: %s...", destination)
-        blob = self.bucket.blob(destination)
+        logger.info("Uploading to: %s...", prefix)
+        blob = self.bucket.blob(prefix)
 
         ## For slow upload speed
         # https://stackoverflow.com/questions/61001454/why-does-upload-from-file-google-cloud-storage-function-throws-timeout-error
 
-        with open(source, "rb") as f:
+        with open(file_path, "rb") as f:
             blob.upload_from_file(f)
-        return destination
+        return prefix
 
-    def _pull(self, source: str, destination: str) -> str:
+    def _pull(self, prefix: str, dir_path: str) -> str:
         """Pulls a model to a destination"""
         try:
-            logger.debug("Downloading from: %s...", source)
-            file_name = os.path.split(source)[1]
-            destination = os.path.join(destination, file_name)
-            blob = self.bucket.blob(source)
+            logger.debug("Downloading from: %s...", prefix)
+            destination = os.path.join(
+                dir_path, 
+                os.path.split(prefix)[1],
+            )
+            blob = self.bucket.blob(prefix)
             blob.download_to_filename(destination)
             return destination
         except NotFound as exc:

--- a/modelstore/storage/local.py
+++ b/modelstore/storage/local.py
@@ -121,7 +121,7 @@ class FileSystemStorage(BlobStorage):
             shutil.copy(origin_path, destination_path)
             return destination_path
         except FileNotFoundError as exc:
-            logger.error(exc)
+            logger.debug(exc)
             raise FilePullFailedException(exc) from exc
 
     def _remove(self, prefix: str) -> bool:

--- a/modelstore/storage/local.py
+++ b/modelstore/storage/local.py
@@ -89,7 +89,10 @@ class FileSystemStorage(BlobStorage):
             return False
 
     def _get_storage_location(self, meta_data: metadata.Storage) -> str:
-        return os.path.join(self.root_prefix, meta_data.path)
+        if self.root_prefix != meta_data.root:
+            warnings.warn("Warning: this model store instance different has a "
+            + "root_dir than the one where the model was saved")
+        return meta_data.path
 
     def _push(self, file_path: str, prefix: str) -> str:
         target_path = os.path.join(
@@ -176,6 +179,7 @@ class FileSystemStorage(BlobStorage):
             prefix,
         )
         try:
+            # pylint: disable=unspecified-encoding
             with open(origin_path, "r") as lines:
                 return json.loads(lines.read())
         except json.JSONDecodeError:

--- a/modelstore/storage/local.py
+++ b/modelstore/storage/local.py
@@ -158,12 +158,13 @@ class FileSystemStorage(BlobStorage):
         """Returns a dict of the location the artifact was stored"""
         return metadata.Storage.from_path(
             storage_type="file_system",
+            root=self.root_prefix,
             path=os.path.abspath(self.relative_dir(prefix))
         )
 
     def _get_storage_location(self, meta_data: metadata.Storage) -> str:
         """Extracts the storage location from a meta data dictionary"""
-        return meta_data.path
+        return os.path.join(self.root_prefix, meta_data.path)
 
     def _read_json_object(self, path: str) -> dict:
         path = self.relative_dir(path)

--- a/tests/metadata/storage/test_storage.py
+++ b/tests/metadata/storage/test_storage.py
@@ -23,12 +23,17 @@ from modelstore.metadata import metadata
 def test_generate_from_path():
     expected = metadata.Storage(
         type="file_system",
+        root="root",
         path="/path/to/files",
         bucket=None,
         container=None,
         prefix=None,
     )
-    result = metadata.Storage.from_path("file_system", "/path/to/files")
+    result = metadata.Storage.from_path(
+        "file_system", 
+        "root",
+        "/path/to/files",
+    )
     assert expected == result
 
     result_dict = json.loads(result.to_json())

--- a/tests/metadata/test_metadata.py
+++ b/tests/metadata/test_metadata.py
@@ -52,7 +52,8 @@ def meta_data(extra_meta_data):
         ),
         storage=metadata.Storage.from_path(
             "example-storage-type",
-            "path-to-files",
+            "root-directory",
+            "path/to/files",
         ),
         modelstore=modelstore.__version__,
         extra=extra_meta_data,

--- a/tests/storage/test_aws.py
+++ b/tests/storage/test_aws.py
@@ -108,146 +108,142 @@ def test_push(moto_boto):
     assert get_file_contents(moto_boto, result) == TEST_FILE_CONTENTS
 
 
-def test_pull(tmp_path):
-    # Push a file to storage
-    storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
-    with TemporaryDirectory() as tmp_dir:
-        _ = storage._push(
-            create_file(tmp_dir),
-            remote_path(),
-        )
+# def test_pull(tmp_path):
+#     # Push a file to storage
+#     storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
+#     with TemporaryDirectory() as tmp_dir:
+#         _ = storage._push(
+#             create_file(tmp_dir),
+#             remote_path(),
+#         )
 
-    # Pull the file back from storage
-    with TemporaryDirectory() as tmp_dir:
-        tmp_path = os.path.join(tmp_dir, TEST_FILE_NAME)
-        result = storage._pull(
-            remote_file_path(),
-            tmp_path,
-        )
+#     # Pull the file back from storage
+#     with TemporaryDirectory() as tmp_dir:
+#         tmp_path = os.path.join(tmp_dir, TEST_FILE_NAME)
+#         result = storage._pull(
+#             remote_file_path(),
+#             tmp_path,
+#         )
 
-        # The correct local path is returned
-        assert result == tmp_path
+#         # The correct local path is returned
+#         assert result == tmp_path
 
-        # The local file exists, with the right content
-        assert os.path.exists(tmp_path)
-        assert file_contains_expected_contents(result)
+#         # The local file exists, with the right content
+#         assert os.path.exists(tmp_path)
+#         assert file_contains_expected_contents(result)
 
 
-@pytest.mark.parametrize(
-    "file_exists,should_call_delete",
-    [
-        (
-            False,
-            False,
-        ),
-        (
-            True,
-            True,
-        ),
-    ],
-)
-def test_remove(file_exists, should_call_delete):
-    # Push a file to storage
-    storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
+# @pytest.mark.parametrize(
+#     "file_exists,should_call_delete",
+#     [
+#         (
+#             False,
+#             False,
+#         ),
+#         (
+#             True,
+#             True,
+#         ),
+#     ],
+# )
+# def test_remove(file_exists, should_call_delete):
+#     # Push a file to storage
+#     storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
     
-    remote_destination = remote_file_path()
-    if file_exists:
-        with TemporaryDirectory() as tmp_dir:
-            _ = storage._push(
-                create_file(tmp_dir),
-                remote_path(),
-            )
+#     remote_destination = remote_file_path()
+#     if file_exists:
+#         with TemporaryDirectory() as tmp_dir:
+#             _ = storage._push(
+#                 create_file(tmp_dir),
+#                 remote_path(),
+#             )
 
-    # pylint: disable=bare-except
-    try:
-        assert storage._remove(remote_destination) == should_call_delete
-    except:
-        # Should fail gracefully here
-        pytest.fail("Remove raised an exception")
+#     # pylint: disable=bare-except
+#     assert storage._remove(remote_destination) == should_call_delete
 
 
-def test_read_json_objects_ignores_non_json(tmp_path):
-    storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
-    prefix = remote_path()
-    # Create files with different suffixes
-    for file_type in ["txt", "json"]:
-        source = os.path.join(tmp_path, f"test-file-source.{file_type}")
-        with open(source, "w") as out:
-            # content
-            out.write(json.dumps({"key": "value"}))
+# def test_read_json_objects_ignores_non_json(tmp_path):
+#     storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
+#     prefix = remote_path()
+#     # Create files with different suffixes
+#     for file_type in ["txt", "json"]:
+#         source = os.path.join(tmp_path, f"test-file-source.{file_type}")
+#         with open(source, "w") as out:
+#             # content
+#             out.write(json.dumps({"key": "value"}))
 
-        # Push the file to storage
-        remote_destination = os.path.join(
-            prefix, f"test-file-destination.{file_type}"
-        )
-        storage._push(source, remote_destination)
+#         # Push the file to storage
+#         remote_destination = os.path.join(
+#             prefix, f"test-file-destination.{file_type}"
+#         )
+#         storage._push(source, remote_destination)
 
-    # Read the json files at the prefix
-    items = storage._read_json_objects(prefix)
-    assert len(items) == 1
-
-
-def test_read_json_object_fails_gracefully(tmp_path):
-    # Push a file that doesn't contain JSON to storage
-    storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
-    prefix = remote_file_path()
-    text_file = os.path.join(tmp_path, "test.txt")
-    # pylint: disable=unspecified-encoding
-    with open(text_file, "w") as out:
-        out.write("some text in a file")
-    remote_path = storage._push(text_file, prefix)
-
-    # Read the json files at the prefix
-    item = storage._read_json_object(remote_path)
-
-    # Return None if we can't decode the JSON
-    assert item is None
+#     # Read the json files at the prefix
+#     items = storage._read_json_objects(prefix)
+#     assert len(items) == 1
 
 
-def test_storage_location():
-    storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
-    prefix = remote_path()
-    # Asserts that the location meta data is correctly formatted
-    expected = metadata.Storage.from_bucket(
-        storage_type="aws:s3",
-        bucket=_MOCK_BUCKET_NAME,
-        prefix=prefix,
-    )
-    assert storage._storage_location(prefix) == expected
+# def test_read_json_object_fails_gracefully(tmp_path):
+#     # Push a file that doesn't contain JSON to storage
+#     storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
+#     prefix = remote_file_path()
+#     text_file = os.path.join(tmp_path, "test.txt")
+#     # pylint: disable=unspecified-encoding
+#     with open(text_file, "w") as out:
+#         out.write("some text in a file")
+#     remote_path = storage._push(text_file, prefix)
+
+#     # Read the json files at the prefix
+#     item = storage._read_json_object(remote_path)
+
+#     # Return None if we can't decode the JSON
+#     assert item is None
 
 
-@pytest.mark.parametrize(
-    "meta_data,should_raise,result",
-    [
-        (
-            metadata.Storage(
-                type=None, 
-                path=None, 
-                bucket=_MOCK_BUCKET_NAME,
-                container=None,
-                prefix="/path/to/file"
-            ),
-            False,
-            "/path/to/file",
-        ),
-        (
-            metadata.Storage(
-                type=None, 
-                path=None, 
-                bucket="a-different-bucket",
-                container=None,
-                prefix="/path/to/file"
-            ),
-            True,
-            None,
-        ),
-    ],
-)
-def test_get_location(meta_data, should_raise, result):
-    # Asserts that pulling the location out of meta data is correct
-    storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
-    if should_raise:
-        with pytest.raises(ValueError):
-            storage._get_storage_location(meta_data)
-    else:
-        assert storage._get_storage_location(meta_data) == result
+# def test_storage_location():
+#     storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
+#     prefix = remote_path()
+#     # Asserts that the location meta data is correctly formatted
+#     expected = metadata.Storage.from_bucket(
+#         storage_type="aws:s3",
+#         bucket=_MOCK_BUCKET_NAME,
+#         prefix=prefix,
+#     )
+#     assert storage._storage_location(prefix) == expected
+
+
+# @pytest.mark.parametrize(
+#     "meta_data,should_raise,result",
+#     [
+#         (
+#             metadata.Storage(
+#                 type=None, 
+#                 path=None, 
+#                 bucket=_MOCK_BUCKET_NAME,
+#                 container=None,
+#                 prefix="/path/to/file"
+#             ),
+#             False,
+#             "/path/to/file",
+#         ),
+#         (
+#             metadata.Storage(
+#                 type=None, 
+#                 path=None, 
+#                 bucket="a-different-bucket",
+#                 container=None,
+#                 prefix="/path/to/file"
+#             ),
+#             True,
+#             None,
+#         ),
+#     ],
+# )
+# def test_get_location(meta_data, should_raise, result):
+#     # Asserts that pulling the location out of meta data is correct
+#     storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
+#     if should_raise:
+#         with pytest.raises(ValueError):
+#             storage._get_storage_location(meta_data)
+#     else:
+#         assert storage._get_storage_location(meta_data) == result

--- a/tests/storage/test_aws.py
+++ b/tests/storage/test_aws.py
@@ -98,7 +98,7 @@ def test_push(moto_boto):
     with TemporaryDirectory() as tmp_dir:
         result = storage._push(
             create_file(tmp_dir),
-            remote_path(),
+            remote_file_path(),
         )
 
     # The correct remote prefix is returned
@@ -108,79 +108,80 @@ def test_push(moto_boto):
     assert get_file_contents(moto_boto, result) == TEST_FILE_CONTENTS
 
 
-# def test_pull(tmp_path):
-#     # Push a file to storage
-#     storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
-#     with TemporaryDirectory() as tmp_dir:
-#         _ = storage._push(
-#             create_file(tmp_dir),
-#             remote_path(),
-#         )
+def test_pull():
+    # Push a file to storage
+    storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
+    with TemporaryDirectory() as tmp_dir:
+        _ = storage._push(
+            create_file(tmp_dir),
+            remote_file_path(),
+        )
 
-#     # Pull the file back from storage
-#     with TemporaryDirectory() as tmp_dir:
-#         tmp_path = os.path.join(tmp_dir, TEST_FILE_NAME)
-#         result = storage._pull(
-#             remote_file_path(),
-#             tmp_path,
-#         )
+    # Pull the file back from storage
+    with TemporaryDirectory() as tmp_dir:
+        result = storage._pull(
+            remote_file_path(),
+            tmp_dir,
+        )
 
-#         # The correct local path is returned
-#         assert result == tmp_path
+        # The correct local path is returned
+        assert result == os.path.join(
+            tmp_dir,
+            TEST_FILE_NAME
+        )
 
-#         # The local file exists, with the right content
-#         assert os.path.exists(tmp_path)
-#         assert file_contains_expected_contents(result)
-
-
-# @pytest.mark.parametrize(
-#     "file_exists,should_call_delete",
-#     [
-#         (
-#             False,
-#             False,
-#         ),
-#         (
-#             True,
-#             True,
-#         ),
-#     ],
-# )
-# def test_remove(file_exists, should_call_delete):
-#     # Push a file to storage
-#     storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
-    
-#     remote_destination = remote_file_path()
-#     if file_exists:
-#         with TemporaryDirectory() as tmp_dir:
-#             _ = storage._push(
-#                 create_file(tmp_dir),
-#                 remote_path(),
-#             )
-
-#     # pylint: disable=bare-except
-#     assert storage._remove(remote_destination) == should_call_delete
+        # The local file exists, with the right content
+        assert os.path.exists(result)
+        assert file_contains_expected_contents(result)
 
 
-# def test_read_json_objects_ignores_non_json(tmp_path):
-#     storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
-#     prefix = remote_path()
-#     # Create files with different suffixes
-#     for file_type in ["txt", "json"]:
-#         source = os.path.join(tmp_path, f"test-file-source.{file_type}")
-#         with open(source, "w") as out:
-#             # content
-#             out.write(json.dumps({"key": "value"}))
+@pytest.mark.parametrize(
+    "file_exists,should_call_delete",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_remove(file_exists, should_call_delete):
+    # Push a file to storage
+    storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
+    remote_destination = remote_file_path()
+    if file_exists:
+        with TemporaryDirectory() as tmp_dir:
+            _ = storage._push(
+                create_file(tmp_dir),
+                remote_file_path(),
+            )
 
-#         # Push the file to storage
-#         remote_destination = os.path.join(
-#             prefix, f"test-file-destination.{file_type}"
-#         )
-#         storage._push(source, remote_destination)
+    # pylint: disable=bare-except
+    assert storage._remove(remote_destination) == should_call_delete
 
-#     # Read the json files at the prefix
-#     items = storage._read_json_objects(prefix)
-#     assert len(items) == 1
+
+def test_read_json_objects_ignores_non_json(tmp_path):
+    storage = AWSStorage(bucket_name=_MOCK_BUCKET_NAME)
+    prefix = remote_path()
+    # Create files with different suffixes
+    for file_type in ["txt", "json"]:
+        source = os.path.join(tmp_path, f"test-file-source.{file_type}")
+        with open(source, "w") as out:
+            # content
+            out.write(json.dumps({"key": "value"}))
+
+        # Push the file to storage
+        remote_destination = os.path.join(
+            prefix, f"test-file-destination.{file_type}"
+        )
+        storage._push(source, remote_destination)
+
+    # Read the json files at the prefix
+    items = storage._read_json_objects(prefix)
+    assert len(items) == 1
 
 
 # def test_read_json_object_fails_gracefully(tmp_path):

--- a/tests/storage/test_azure.py
+++ b/tests/storage/test_azure.py
@@ -34,7 +34,7 @@ from tests.storage.test_utils import (
     file_contains_expected_contents,
     remote_file_path,
     remote_path,
-    temp_file,
+    create_file,
 )
 
 # pylint: disable=redefined-outer-name

--- a/tests/storage/test_azure.py
+++ b/tests/storage/test_azure.py
@@ -34,7 +34,7 @@ from tests.storage.test_utils import (
     file_contains_expected_contents,
     remote_file_path,
     remote_path,
-    create_file,
+    push_temp_file,
 )
 
 # pylint: disable=redefined-outer-name
@@ -134,20 +134,21 @@ def test_validate(container_exists, validate_should_pass):
     assert storage.validate() == validate_should_pass
 
 
-def test_push(tmp_path):
+def test_push():
     # Create a mock storage instance
     blob_service_client = mock_blob_service_client(
         container_exists=True,
         files_exist=False,
     )
-    storage = azure_storage(blob_service_client)
 
-    # Push a file to storage
-    prefix = remote_file_path()
-    storage._push(temp_file(tmp_path), prefix)
+    storage = azure_storage(blob_service_client)
+    result = push_temp_file(storage)
+
+    # The correct remote prefix is returned
+    assert result == remote_file_path()
 
     # Asserts that pushing a file results in an upload
-    blob_client = storage._blob_client(prefix)
+    blob_client = storage._blob_client(result)
     blob_client.upload_blob.assert_called()
 
 

--- a/tests/storage/test_blob_storage_meta_data.py
+++ b/tests/storage/test_blob_storage_meta_data.py
@@ -18,8 +18,9 @@ from modelstore.metadata import metadata
 from modelstore.storage.util.paths import (
     MODELSTORE_ROOT_PREFIX,
     get_domain_path,
-    get_models_path,
+    get_model_version_path,
 )
+from modelstore.utils.exceptions import DomainNotFoundException
 
 # pylint: disable=unused-import
 from tests.storage.test_blob_storage import (
@@ -66,18 +67,6 @@ def test_list_models(mock_blob_storage):
     assert models[1] == "model-1"
 
 
-def test_get_metadata_path(mock_blob_storage):
-    exp = os.path.join(
-        mock_blob_storage.root_prefix,
-        MODELSTORE_ROOT_PREFIX,
-        "domain",
-        "versions",
-        "model-id.json",
-    )
-    res = mock_blob_storage._get_metadata_path("domain", "model-id")
-    assert exp == res
-
-
 def test_set_meta_data(mock_blob_storage):
     # Set the meta data of a fake model
     meta_data = mock_meta_data("domain-1", "model-1", inc_time=0)
@@ -89,12 +78,10 @@ def test_set_meta_data(mock_blob_storage):
     assert_file_contents_equals(domain_meta_data_path, meta_data)
 
     # (2) The meta data for a specific model
-    model_meta_data_path = os.path.join(
-        get_models_path(
-            mock_blob_storage.root_prefix,
-            "domain-1"
-        ),
-        "model-1.json",
+    model_meta_data_path = get_model_version_path(
+        mock_blob_storage.root_prefix,
+        "domain-1",
+        "model-1",
     )
     assert_file_contents_equals(model_meta_data_path, meta_data)
 
@@ -116,5 +103,5 @@ def test_get_meta_data(mock_blob_storage):
     [(None, "model-2"), ("", "model-2"), ("domain-1", None), ("domain-1", "")],
 )
 def test_get_meta_data_undefined_input(mock_blob_storage, domain, model_id):
-    with pytest.raises(ValueError):
+    with pytest.raises(DomainNotFoundException):
         mock_blob_storage.get_meta_data(domain, model_id)

--- a/tests/storage/test_local.py
+++ b/tests/storage/test_local.py
@@ -164,6 +164,7 @@ def test_storage_location(file_system_storage):
     prefix = remote_file_path()
     expected = metadata.Storage.from_path(
         storage_type="file_system",
+        root=file_system_storage.root_prefix,
         path=os.path.join(file_system_storage.root_prefix, prefix)
     )
     result = file_system_storage._storage_location(prefix)

--- a/tests/storage/test_local.py
+++ b/tests/storage/test_local.py
@@ -29,6 +29,7 @@ from tests.storage.test_utils import (
     remote_file_path,
     remote_path,
     push_temp_file,
+    push_temp_files,
 )
 
 # pylint: disable=protected-access
@@ -136,20 +137,7 @@ def test_remove(file_exists, should_call_delete, file_system_storage):
 def test_read_json_objects_ignores_non_json(file_system_storage):
     # Create files with different suffixes
     prefix = remote_path()
-    with TemporaryDirectory() as tmp_dir:
-        for file_type in ["txt", "json"]:
-            file_name = f"test-file-source.{file_type}"
-            file_path = os.path.join(tmp_dir, file_name)
-            # pylint: disable=unspecified-encoding
-            with open(file_path, "w") as out:
-                out.write(json.dumps({"key": "value"}))
-
-            # Push the file to storage
-            result = file_system_storage._push(
-                file_path,
-                os.path.join(prefix, file_name)
-            )
-            assert result == os.path.join(prefix, file_name)
+    push_temp_files(file_system_storage, prefix)
 
     # Read the json files at the prefix
     items = file_system_storage._read_json_objects(prefix)

--- a/tests/storage/test_utils.py
+++ b/tests/storage/test_utils.py
@@ -11,6 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+from tempfile import TemporaryDirectory
 import json
 import os
 
@@ -44,3 +45,13 @@ def remote_path():
 
 def remote_file_path():
     return os.path.join(remote_path(), TEST_FILE_NAME)
+
+
+def push_temp_file(storage, contents = None) -> str:
+    with TemporaryDirectory() as tmp_dir:
+        # pylint: disable=protected-access
+        result = storage._push(
+            create_file(tmp_dir, contents),
+            remote_file_path(),
+        )
+    return result

--- a/tests/storage/test_utils.py
+++ b/tests/storage/test_utils.py
@@ -20,6 +20,7 @@ import os
 TEST_FILE_NAME = "test-file.txt"
 TEST_FILE_CONTENTS = json.dumps({"k": "v"})
 TEST_FILE_LIST = [f"test-file-{i}.json" for i in range(3)]
+TEST_FILE_TYPES = ["json", "txt"]
 
 
 def create_file(tmp_path, contents = None):
@@ -55,3 +56,21 @@ def push_temp_file(storage, contents = None) -> str:
             remote_file_path(),
         )
     return result
+
+
+def push_temp_files(storage, prefix, file_types=TEST_FILE_TYPES):
+    with TemporaryDirectory() as tmp_dir:
+        for file_type in file_types:
+            file_name = f"test-file-source.{file_type}"
+            file_path = os.path.join(tmp_dir, file_name)
+            # pylint: disable=unspecified-encoding
+            with open(file_path, "w") as out:
+                out.write(json.dumps({"key": "value"}))
+
+            # Push the file to storage
+            # pylint: disable=protected-access
+            result = storage._push(
+                file_path,
+                os.path.join(prefix, file_name)
+            )
+            assert result == os.path.join(prefix, file_name)

--- a/tests/storage/test_utils.py
+++ b/tests/storage/test_utils.py
@@ -21,8 +21,10 @@ TEST_FILE_CONTENTS = json.dumps({"k": "v"})
 TEST_FILE_LIST = [f"test-file-{i}.json" for i in range(3)]
 
 
-def temp_file(tmp_path, contents=TEST_FILE_CONTENTS):
+def create_file(tmp_path, contents):
     # pylint: disable=unspecified-encoding
+    if contents is None:
+        contents = TEST_FILE_CONTENTS
     source = os.path.join(tmp_path, TEST_FILE_NAME)
     with open(source, "w") as out:
         out.write(contents)

--- a/tests/storage/test_utils.py
+++ b/tests/storage/test_utils.py
@@ -21,7 +21,7 @@ TEST_FILE_CONTENTS = json.dumps({"k": "v"})
 TEST_FILE_LIST = [f"test-file-{i}.json" for i in range(3)]
 
 
-def create_file(tmp_path, contents):
+def create_file(tmp_path, contents = None):
     # pylint: disable=unspecified-encoding
     if contents is None:
         contents = TEST_FILE_CONTENTS

--- a/tests/storage/util/test_paths.py
+++ b/tests/storage/util/test_paths.py
@@ -38,27 +38,74 @@ def test_get_archive_path(tmp_path, has_root_prefix):
 
 
 @pytest.mark.parametrize("has_root_prefix", [(True), (False)])
-def test_get_models_path_no_root_prefix(tmp_path, has_root_prefix):
+def test_get_model_versions_path_no_root_prefix(tmp_path, has_root_prefix):
     root = str(tmp_path) if has_root_prefix else ""
-    exp = os.path.join(root, paths.MODELSTORE_ROOT_PREFIX, "example-domain", "versions")
-    res = paths.get_models_path(root, "example-domain")
+    exp = os.path.join(
+        root,
+        paths.MODELSTORE_ROOT_PREFIX,
+        "domain",
+        "versions",
+    )
+    res = paths.get_model_versions_path(root, "domain")
     assert exp == res
 
 
 @pytest.mark.parametrize("has_root_prefix", [(True), (False)])
-def test_get_models_path_with_state(tmp_path, has_root_prefix):
+def test_get_model_versions_path_with_state(tmp_path, has_root_prefix):
     root = str(tmp_path) if has_root_prefix else ""
     exp = os.path.join(
-        root, paths.MODELSTORE_ROOT_PREFIX, "example-domain", "versions", "prod"
+        root,
+        paths.MODELSTORE_ROOT_PREFIX,
+        "domain",
+        "versions",
+        "prod",
     )
-    res = paths.get_models_path(root, "example-domain", "prod")
+    res = paths.get_model_versions_path(root, "domain", "prod")
+    assert exp == res
+
+
+@pytest.mark.parametrize("has_root_prefix", [(True), (False)])
+def test_get_model_version_path(tmp_path, has_root_prefix):
+    root = str(tmp_path) if has_root_prefix else ""
+    exp = os.path.join(
+        root,
+        paths.MODELSTORE_ROOT_PREFIX,
+        "domain",
+        "versions",
+        "model-id.json",
+    )
+    res = paths.get_model_version_path(root, "domain", "model-id")
+    assert exp == res
+
+
+@pytest.mark.parametrize("has_root_prefix", [(True), (False)])
+def test_get_model_version_with_state_path(tmp_path, has_root_prefix):
+    root = str(tmp_path) if has_root_prefix else ""
+    exp = os.path.join(
+        root,
+        paths.MODELSTORE_ROOT_PREFIX,
+        "domain",
+        "versions",
+        "prod",
+        "model-id.json",
+    )
+    res = paths.get_model_version_path(
+        root,
+        "domain",
+        "model-id",
+        state_name="prod",
+    )
     assert exp == res
 
 
 @pytest.mark.parametrize("has_root_prefix", [(True), (False)])
 def test_get_domains_path(tmp_path, has_root_prefix):
     root = str(tmp_path) if has_root_prefix else ""
-    exp = os.path.join(root, paths.MODELSTORE_ROOT_PREFIX, "domains")
+    exp = os.path.join(
+        root,
+        paths.MODELSTORE_ROOT_PREFIX,
+        "domains",
+    )
     res = paths.get_domains_path(root)
     assert exp == res
 
@@ -66,15 +113,24 @@ def test_get_domains_path(tmp_path, has_root_prefix):
 @pytest.mark.parametrize("has_root_prefix", [(True), (False)])
 def test_get_domain_path(tmp_path, has_root_prefix):
     root = str(tmp_path) if has_root_prefix else ""
-    exp = os.path.join(paths.MODELSTORE_ROOT_PREFIX, "domains", "domain.json")
-    res = paths.get_domain_path("", "domain")
+    exp = os.path.join(
+        root,
+        paths.MODELSTORE_ROOT_PREFIX,
+        "domains",
+        "domain.json",
+    )
+    res = paths.get_domain_path(root, "domain")
     assert exp == res
 
 
 @pytest.mark.parametrize("has_root_prefix", [(True), (False)])
 def test_get_model_states_path(tmp_path, has_root_prefix):
     root = str(tmp_path) if has_root_prefix else ""
-    exp = os.path.join(root, paths.MODELSTORE_ROOT_PREFIX, "model_states")
+    exp = os.path.join(
+        root,
+        paths.MODELSTORE_ROOT_PREFIX,
+        "model_states",
+    )
     res = paths.get_model_states_path(root)
     assert exp == res
 
@@ -82,6 +138,11 @@ def test_get_model_states_path(tmp_path, has_root_prefix):
 @pytest.mark.parametrize("has_root_prefix", [(True), (False)])
 def test_get_model_state_path(tmp_path, has_root_prefix):
     root = str(tmp_path) if has_root_prefix else ""
-    exp = os.path.join(root, paths.MODELSTORE_ROOT_PREFIX, "model_states", "prod.json")
+    exp = os.path.join(
+        root,
+        paths.MODELSTORE_ROOT_PREFIX,
+        "model_states",
+        "prod.json",
+    )
     res = paths.get_model_state_path(root, "prod")
     assert exp == res

--- a/tests/test_model_store.py
+++ b/tests/test_model_store.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-from pathlib import PosixPath, Path
+from pathlib import PosixPath
 import os
 
 import pytest
@@ -26,18 +26,15 @@ from modelstore.utils.exceptions import (
 
 # pylint: disable=missing-function-docstring
 # pylint: disable=redefined-outer-name
+# pylint: disable=unused-import
+from tests.test_utils import (
+    model_file,
+)
 
 
 @pytest.fixture
 def model_store(tmp_path: PosixPath):
     return ModelStore.from_file_system(root_directory=str(tmp_path))
-
-
-@pytest.fixture
-def model_file(tmp_path: PosixPath):
-    file_path = os.path.join(tmp_path, "model.txt")
-    Path(file_path).touch()
-    return file_path
 
 
 def test_model_not_found(model_store: ModelStore, model_file: str):

--- a/tests/test_model_store.py
+++ b/tests/test_model_store.py
@@ -20,6 +20,7 @@ from modelstore.model_store import ModelStore
 from modelstore.storage.states.model_states import ReservedModelStates
 from modelstore.utils.exceptions import (
     ModelExistsException,
+    DomainNotFoundException,
     ModelNotFoundException,
 )
 
@@ -39,9 +40,17 @@ def model_file(tmp_path: PosixPath):
     return file_path
 
 
-def test_model_not_found(model_store: ModelStore):
-    with pytest.raises(ModelNotFoundException):
+def test_model_not_found(model_store: ModelStore, model_file: str):
+    with pytest.raises(DomainNotFoundException):
         model_store.get_model_info("missing-domain", "missing-model")
+
+    model_store.upload(
+        domain="existing-domain",
+        model_id="test-model-id-1",
+        model=model_file
+    )
+    with pytest.raises(ModelNotFoundException):
+        model_store.get_model_info("existing-domain", "missing-model")
 
 
 def test_model_exists(model_store: ModelStore, model_file: str):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 from functools import partial
+from pathlib import PosixPath, Path
+import os
 
 import pytest
 from modelstore.model_store import ModelStore
@@ -53,3 +55,10 @@ def validate_library_attributes(store: ModelStore, allowed: list, not_allowed: l
         assert isinstance(mgr, MissingDepManager)
         with pytest.raises(ModuleNotFoundError):
             mgr.upload(domain="test", model_id="model-id", model="test")
+
+
+@pytest.fixture
+def model_file(tmp_path: PosixPath):
+    file_path = os.path.join(tmp_path, "model.txt")
+    Path(file_path).touch()
+    return file_path

--- a/workflows/actions/models.py
+++ b/workflows/actions/models.py
@@ -19,7 +19,7 @@ from modelstore import ModelStore
 from modelstore.utils import exceptions
 
 
-def assert_get_missing_model_raises(model_store: ModelStore, domain: str):
+def assert_get_missing_model_raises(model_store: ModelStore, domain: str, _: dict):
     """ Calling get_model_info() for a missing model raise an exception """
     try:
         _ = model_store.get_model_info(domain, "missing-model")

--- a/workflows/actions/models.py
+++ b/workflows/actions/models.py
@@ -19,6 +19,16 @@ from modelstore import ModelStore
 from modelstore.utils import exceptions
 
 
+def assert_get_missing_model_raises(model_store: ModelStore, domain: str):
+    """ Calling get_model_info() for a missing model raise an exception """
+    try:
+        _ = model_store.get_model_info(domain, "missing-model")
+    except exceptions.ModelNotFoundException:
+        print("✅  Modelstore raises a ModelNotFoundException if it can't find a model")
+        return
+    raise AssertionError("failed to raise ModelNotFoundException")
+
+
 def assert_list_domains(model_store: ModelStore, domain: str, _: dict):
     """ The result of listing all domains contains the `domain` value """
     domains = model_store.list_domains()
@@ -101,6 +111,7 @@ def get_actions() -> List[Callable]:
     """ Returns the set of actions that can be run on a model_store
     after a model has been uploaded """
     return [
+        assert_get_missing_model_raises,
         assert_list_domains,
         assert_get_domain,
         assert_list_models,

--- a/workflows/actions/storage.py
+++ b/workflows/actions/storage.py
@@ -26,16 +26,6 @@ def assert_get_missing_domain_raises(model_store: ModelStore, _: str):
     raise AssertionError("failed to raise DomainNotFoundException")
 
 
-def assert_get_missing_model_raises(model_store: ModelStore, domain: str):
-    """ Calling get_model_info() for a missing model raise an exception """
-    try:
-        _ = model_store.get_model_info(domain, "missing-model")
-    except exceptions.ModelNotFoundException:
-        print("✅  Modelstore raises a ModelNotFoundException if it can't find a model")
-        return
-    raise AssertionError("failed to raise ModelNotFoundException")
-
-
 def assert_create_model_states(model_store: ModelStore, _: str):
     """ Creating, listing and getting model states """
     state_names = ["staging", "production"]
@@ -51,6 +41,5 @@ def get_actions() -> List[Callable]:
     """ Returns the set of actions that can be run on a model_store """
     return [
         assert_get_missing_domain_raises,
-        assert_get_missing_model_raises,
         assert_create_model_states,
     ]


### PR DESCRIPTION
This (rather large) PR seeks to address this issue:

- https://github.com/operatorai/modelstore/issues/189

Specifically, if a `modelstore` instance is created in one location and then the root directory is manually moved elsewhere (e.g. mounted into a container), the models can't be loaded from the new location because of how the local storage was implemented.

This PR adds a new field to the storage meta data that differentiates the `root_dir` from the `prefix` and also refactors/cleans up a bunch of tests.