### PR TITLE
Add `secure = False` option to MinIO arguments

### DIFF
--- a/modelstore/model_store.py
+++ b/modelstore/model_store.py
@@ -106,6 +106,7 @@ class ModelStore:
         secret_key: Optional[str] = None,
         bucket_name: Optional[str] = None,
         root_prefix: Optional[str] = None,
+        secure: Optional[bool] = False
     ) -> "ModelStore":
         """Creates a ModelStore instance that stores models using a MinIO client.
         This assumes that the bucket already exists."""
@@ -113,7 +114,7 @@ class ModelStore:
             raise ModuleNotFoundError("minio is not installed!")
         return ModelStore(
             storage=MinIOStorage(
-                endpoint, access_key, secret_key, bucket_name, root_prefix
+                endpoint, access_key, secret_key, bucket_name, root_prefix, secure
             )
         )
 

--- a/modelstore/model_store.py
+++ b/modelstore/model_store.py
@@ -106,7 +106,7 @@ class ModelStore:
         secret_key: Optional[str] = None,
         bucket_name: Optional[str] = None,
         root_prefix: Optional[str] = None,
-        secure: Optional[bool] = False
+        secure: Optional[bool] = True
     ) -> "ModelStore":
         """Creates a ModelStore instance that stores models using a MinIO client.
         This assumes that the bucket already exists."""

--- a/modelstore/storage/minio.py
+++ b/modelstore/storage/minio.py
@@ -62,6 +62,7 @@ class MinIOStorage(BlobStorage):
         bucket_name: Optional[str] = None,
         root_prefix: Optional[str] = None,
         client: "Minio" = None,
+        secure: bool = True,
     ):
         super().__init__(["minio"], root_prefix, "MODEL_STORE_MINIO_ROOT_PREFIX")
         # If arguments are None, try to populate them using environment variables
@@ -79,6 +80,7 @@ class MinIOStorage(BlobStorage):
             return
         self.access_key = environment.get_value(access_key, "MINIO_ACCESS_KEY")
         self.secret_key = environment.get_value(secret_key, "MINIO_SECRET_KEY")
+        self.secure = secure
 
     @property
     def client(self):
@@ -88,6 +90,7 @@ class MinIOStorage(BlobStorage):
                 self.endpoint,
                 access_key=self.access_key,
                 secret_key=self.secret_key,
+                secure=self.secure
             )
         return self.__client
 

--- a/modelstore/storage/minio.py
+++ b/modelstore/storage/minio.py
@@ -62,7 +62,7 @@ class MinIOStorage(BlobStorage):
         bucket_name: Optional[str] = None,
         root_prefix: Optional[str] = None,
         client: "Minio" = None,
-        secure: bool = True,
+        secure: Optional[bool] = True,
     ):
         super().__init__(["minio"], root_prefix, "MODEL_STORE_MINIO_ROOT_PREFIX")
         # If arguments are None, try to populate them using environment variables


### PR DESCRIPTION
Add a new argument (`secure: Optional[bool] = True`) to the MinIOStorage class, and the `from_minio` method of the `ModelStore` class.
This argument defaults to `True`, which is the default of the underlying `minio.Minio` class.
This argument is passed directly to the argument of the same name in the `minio.Minio` class, and disables the need for SSL connections when set to `False`, thereby allowing development against a local MinIO server that doesn't have SSL enabled.