### PR TITLE
Ignore fastai tests on darwin

### DIFF
--- a/tests/models/test_fastai.py
+++ b/tests/models/test_fastai.py
@@ -17,9 +17,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-import torch
-import fastai
-
 # pylint: disable=unused-import
 from fastai.learner import load_learner
 from fastai.callback.schedule import fit_one_cycle

--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -12,12 +12,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 from random import randint
+import sys
 
 import pandas as pd
 import pytest
 from sklearn.datasets import make_classification
 
 # pylint: disable=missing-function-docstring
+
+
+def is_macos() -> bool:
+    return sys.platform == "darwin"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
The `fastai` tests are trying to force MPS on my laptop, even though it does not have MPS hardware. This results in a `RuntimeError`:

```
E       RuntimeError: Exception occured in `TrainEvalCallback` when calling event `before_fit`:
E       	The MPS backend is supported on MacOS 12.3+.Current OS version can be queried using `sw_vers`
```