### PR TITLE
Add entrypoint to setup.py for CLI usage (#252)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,7 @@ setup(
     license="Please refer to the readme",
     python_requires=">=3.6",
     install_requires=requirements,
+    entry_points={
+        'console_scripts': ['modelstore=modelstore.__main__:cli']
+    },
 )


### PR DESCRIPTION
**Related Issue**:
- #252 

**Description**:
- Added an entrypoint in setup.py to allow using the CLI as `modelstore --help` instead of `python -m modelstore --help`.

**Changes**:
- Updated `setup.py` to include `entry_points`.

**How to Test**:
- Install the package locally using `pip install -e .`.
- Use the `modelstore --help` command to check its functionality.

**Screenshots**:
- 
<img width="1135" alt="image" src="https://github.com/operatorai/modelstore/assets/48901587/02c7a250-8007-4825-bac2-52a599e69208">

<img width="945" alt="image" src="https://github.com/operatorai/modelstore/assets/48901587/ac95c91a-7385-40c0-8718-0a52a5ac3258">
