### PR TITLE
Do not use os.getcwd() for creating model archives (+ onnx issue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ With thanks to [Tom in the MLOps Community](https://mlops-community.slack.com/ar
 
 * Model store cleans up temporary files that it generates, even if downloads or uploads are cancelled mid flight [#258](https://github.com/operatorai/modelstore/pull/258).
 
+And thanks to [Michael in the MLOps Community](https://mlops-community.slack.com/archives/C0227QJCDS8/p1695397710224629) for the feedback:
+
+* Model store no longer creates its `artifacts.tar.gz` in the `os.getcwd()`, which was preventing modelstore from being used for parallel uploads [#266](https://github.com/operatorai/modelstore/pull/266).
+
 ## modelstore 0.0.79 ([June 2023](https://github.com/operatorai/modelstore/pull/243))
 
 **🆕  New functionality**

--- a/modelstore/model_store.py
+++ b/modelstore/model_store.py
@@ -262,14 +262,13 @@ class ModelStore:
             raise ValueError(f"model_id='{model_id}' contains invalid characters")
 
         # Figure out which library the kwargs match with
-        # We do this _before_ checking whether the model exists to raise
+        # We do this _before_ checking whether the model exists to
         # catch if the kwargs aren't quite right before potentially modifying
         # model state, below
         # pylint: disable=no-member
         managers = matching_managers(self._libraries, **kwargs)
-        if len(managers) == 1:
-            manager = managers[0]
-        else:
+        manager = managers[0]
+        if len(managers) > 1:
             # There are cases where we can match on more than one
             # manager (e.g., a model and an explainer)
             manager = MultipleModelsManager(managers, self.storage)

--- a/requirements-dev1.txt
+++ b/requirements-dev1.txt
@@ -19,7 +19,7 @@ Keras-Preprocessing>=1.1.2
 lightgbm>=3.3.2
 mxnet>=1.8.0.post0
 onnx==1.12.0 # onnx 1.13.0 depends on protobuf<4 and >=3.20.2, which breaks everything else
-onnxruntime>=1.11.0
+onnxruntime>=1.11.0,<1.16.0 # https://github.com/microsoft/onnxruntime/issues/17631
 prophet>=1.0.1
 pyspark>=3.3.1
 pytorch-lightning>=1.6.1

--- a/requirements-dev1.txt
+++ b/requirements-dev1.txt
@@ -7,7 +7,7 @@ azure-storage-blob>=12.11.0
 boto3>=1.21.41
 google-cloud-storage>=2.3.0
 minio>=7.1.12
-pydoop<=2.0.0; sys_platform == 'darwin'
+#pydoop<=2.0.0; sys_platform == 'darwin'
 pystan>=2.19.1.1 # required to be installed before prophet
 
 # Machine Learning

--- a/tests/models/test_pyspark.py
+++ b/tests/models/test_pyspark.py
@@ -71,6 +71,7 @@ def test_model_data(spark_manager, spark_model):
 
 
 def test_required_kwargs(spark_manager):
+    # pylint: disable=protected-access
     assert spark_manager._required_kwargs() == ["model"]
 
 
@@ -81,6 +82,7 @@ def test_matches_with(spark_manager, spark_model):
 
 
 def test_get_functions(spark_manager, spark_model):
+    # pylint: disable=protected-access
     assert len(spark_manager._get_functions(model=spark_model)) == 1
 
 

--- a/tests/models/test_pyspark.py
+++ b/tests/models/test_pyspark.py
@@ -12,7 +12,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 import os
-import platform
 
 import numpy as np
 import pytest
@@ -98,12 +97,12 @@ def test_save_model(spark_model, tmp_path):
     ]
     assert exp == res
     exists_fn = os.path.exists
-    if platform.system() == "Darwin":
-        # Running hadoop locally, so need to check
-        # for the files in hdfs
-        import pydoop.hdfs as hdfs
+    # if platform.system() == "Darwin":
+    #     # Running hadoop locally, so need to check
+    #     # for the files in hdfs
+    #     import pydoop.hdfs as hdfs
 
-        exists_fn = hdfs.path.exists
+    #     exists_fn = hdfs.path.exists
     assert all(exists_fn(x) for x in exp)
 
 

--- a/tests/models/test_xgboost.py
+++ b/tests/models/test_xgboost.py
@@ -18,7 +18,6 @@ import pytest
 import xgboost as xgb
 
 from modelstore.metadata import metadata
-from modelstore.metadata.dataset.dataset import Features, Labels
 from modelstore.models import xgboost
 
 # pylint: disable=unused-import

--- a/tests/storage/test_hdfs.py
+++ b/tests/storage/test_hdfs.py
@@ -32,16 +32,12 @@ from tests.storage.test_utils import (
 # pylint: disable=missing-function-docstring
 
 
-def is_not_mac() -> bool:
-    return platform.system() != "Darwin"
-
-
 @pytest.fixture
 def storage(tmp_path):
     return HdfsStorage(root_prefix=str(tmp_path), create_directory=True)
 
 
-@pytest.mark.skipif(is_not_mac(), reason="no hadoop in ci")
+@pytest.mark.skip(reason="no hadoop installed")
 def test_create_from_environment_variables(monkeypatch):
     # Does not fail when environment variables exist
     for key in HdfsStorage.BUILD_FROM_ENVIRONMENT.get("required", []):
@@ -52,12 +48,12 @@ def test_create_from_environment_variables(monkeypatch):
         pytest.fail("Failed to initialise storage from env variables")
 
 
-@pytest.mark.skipif(is_not_mac(), reason="no hadoop in ci")
+@pytest.mark.skip(reason="no hadoop installed")
 def test_validate(storage):
     assert storage.validate()
 
 
-@pytest.mark.skipif(is_not_mac(), reason="no hadoop in ci")
+@pytest.mark.skip(reason="no hadoop installed")
 def test_push_and_pull(storage, tmp_path):
     # pylint: disable=import-outside-toplevel
     import pydoop.hdfs as hdfs
@@ -73,7 +69,7 @@ def test_push_and_pull(storage, tmp_path):
     hdfs.rm(files[0])
 
 
-@pytest.mark.skipif(is_not_mac(), reason="no hadoop in ci")
+@pytest.mark.skip(reason="no hadoop installed")
 @pytest.mark.parametrize(
     "file_exists,should_call_delete",
     [
@@ -96,7 +92,7 @@ def test_remove(storage, file_exists, should_call_delete):
     assert not os.path.exists(prefix)
 
 
-@pytest.mark.skipif(is_not_mac(), reason="no hadoop in ci")
+@pytest.mark.skip(reason="no hadoop installed")
 def test_read_json_objects_ignores_non_json(storage):
     # pylint: disable=import-outside-toplevel
     import pydoop.hdfs as hdfs
@@ -112,7 +108,7 @@ def test_read_json_objects_ignores_non_json(storage):
     _ = [hdfs.rm(f) for f in hdfs.ls(prefix)]
 
 
-@pytest.mark.skipif(is_not_mac(), reason="no hadoop in ci")
+@pytest.mark.skip(reason="no hadoop installed")
 def test_storage_location(storage):
     prefix = remote_path()
     # Asserts that the location meta data is correctly formatted
@@ -124,7 +120,7 @@ def test_storage_location(storage):
     assert storage._storage_location(prefix) == expected
 
 
-@pytest.mark.skipif(is_not_mac(), reason="no hadoop in ci")
+@pytest.mark.skip(reason="no hadoop installed")
 @pytest.mark.parametrize(
     "meta_data,should_raise,result",
     [

--- a/tests/storage/test_hdfs.py
+++ b/tests/storage/test_hdfs.py
@@ -12,7 +12,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 import os
-import platform
 
 import pytest
 


### PR DESCRIPTION
closes #263

Also fixes:

- Param changes in the latest xgboost
- An ORT issue with onnx https://github.com/microsoft/onnxruntime/issues/17631

HDFS / pydoop tests are now being skipped, to reduce needing to install this across platforms.