### PR TITLE
Fix dead neptune.ai blog link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Is there a machine learning framework that is missing?
 
 * [35 Hidden Python Libraries That Are Absolute Gems](https://www.blog.dailydoseofds.com/p/35-gem-py-libs), March 2023
 * [Evidently.AI AMA with Neal Lathia](https://www.evidentlyai.com/blog/ama-neal-lathia), January 2023
-* [MLOps Model Stores: Definition, Functionality, Tools Review](https://neptune.ai/blog/mlops-model-stores), January 2023
+* [MLOps Model Stores: Definition, Functionality, Tools Review](https://web.archive.org/web/20231208122806/https://neptune.ai/blog/mlops-model-stores), January 2023
 * [Monzo's machine learning stack](https://monzo.com/blog/2022/04/26/monzos-machine-learning-stack), April 2022
 * [Data Talks Club Minis: Model Store](https://www.youtube.com/watch?v=85BWnKmOZl8), July 2021
 * [Model arterfacts: the war stories](https://nlathia.github.io/2020/09/Model-artifacts-war-stories.html), September 2020


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now 308-redirects to a press-release page, so the neptune.ai/blog link(s) below no longer lead to the referenced article(s).

This PR fixes 1 dead link in `README.md`, pointing the *"MLOps Model Stores"* reference to the Wayback Machine snapshot of the original article. Note: the last clean (HTTP 200) capture of that URL dates to December 2023 — the URL appears to have been renamed/redirected before the acquisition; the snapshot preserves the content that was originally linked.